### PR TITLE
[BS-511] Add key checks to Join areUniqueColumns check

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdColumnUniqueness.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdColumnUniqueness.java
@@ -328,11 +328,9 @@ public class RelMdColumnUniqueness
             // An outer join may not have the columns equal
             boolean foundArg0 = combinedLeftBits.get(arg0);
             boolean foundArg1 = combinedLeftBits.get(arg1);
-            if (foundArg0 && !foundArg1) {
-              addedLeftCols.set(arg1);
-              bitAdded = true;
-            } else if (!foundArg0 && foundArg1) {
+            if ((foundArg0 && !foundArg1) || (!foundArg0 && foundArg1)) {
               addedLeftCols.set(arg0);
+              addedLeftCols.set(arg1);
               bitAdded = true;
             } else {
               unmatchedEqualities.add(equals);
@@ -346,11 +344,9 @@ public class RelMdColumnUniqueness
             arg1 = arg1 - numLeftCols;
             boolean foundArg0 = combinedRightBits.get(arg0);
             boolean foundArg1 = combinedRightBits.get(arg1);
-            if (foundArg0 && !foundArg1) {
-              addedRightCols.set(arg1);
-              bitAdded = true;
-            } else if (!foundArg0 && foundArg1) {
+            if ((foundArg0 && !foundArg1) || (!foundArg0 && foundArg1)) {
               addedRightCols.set(arg0);
+              addedRightCols.set(arg1);
               bitAdded = true;
             } else {
               unmatchedEqualities.add(equals);
@@ -440,7 +436,7 @@ public class RelMdColumnUniqueness
   }
 
   /**
-   * Takes a RexNode that represents a condition and finas
+   * Takes a RexNode that represents a condition and finds
    * all equalities that are always True. This is used by Join
    * to help identify when the columns are unique.
    */

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdColumnUniqueness.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdColumnUniqueness.java
@@ -44,6 +44,7 @@ import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexProgram;
+import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.Pair;
@@ -54,6 +55,7 @@ import com.google.common.collect.ImmutableList;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.ArrayList;
+import java.util.BitSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -285,20 +287,60 @@ public class RelMdColumnUniqueness
       return mq.areColumnsUnique(left, columns, ignoreNulls);
     }
 
+    int numLeftCols = rel.getLeft().getRowType().getFieldCount();
+
     // Divide up the input column mask into column masks for the left and
     // right sides of the join
     final Pair<ImmutableBitSet, ImmutableBitSet> leftAndRightColumns =
-        splitLeftAndRightColumns(rel.getLeft().getRowType().getFieldCount(),
+        splitLeftAndRightColumns(numLeftCols,
             columns);
-    final ImmutableBitSet leftColumns = leftAndRightColumns.left;
-    final ImmutableBitSet rightColumns = leftAndRightColumns.right;
+    final ImmutableBitSet initLeftColumns = leftAndRightColumns.left;
+    final ImmutableBitSet initRightColumns = leftAndRightColumns.right;
 
     // for FULL OUTER JOIN if columns contain column from both inputs it is not
     // guaranteed that the result will be unique
     if (!ignoreNulls && rel.getJoinType() == JoinRelType.FULL
-        && leftColumns.cardinality() > 0 && rightColumns.cardinality() > 0) {
+        && initLeftColumns.cardinality() > 0 && initRightColumns.cardinality() > 0) {
       return false;
     }
+
+    // If we have an inner join on either side, we may be able to determine
+    // uniqueness from the condition.
+    HashSet<RexCall> equalities = findCommonEqualities(rel.getCondition());
+    // Check each equality. If we are only checking uniqueness with a single
+    // side we can include the other side.
+    BitSet addedLeftCols = new BitSet();
+    BitSet addedRightCols = new BitSet();
+    boolean isOuterLeft = rel.getJoinType().generatesNullsOnRight();
+    boolean isOuterRight = rel.getJoinType().generatesNullsOnLeft();
+    for (RexCall equals: equalities) {
+      Integer arg0 = ((RexInputRef) equals.getOperands().get(0)).getIndex();
+      Integer arg1 = ((RexInputRef) equals.getOperands().get(1)).getIndex();
+      // Left and right must not be in the same table
+      if ((arg0 < numLeftCols && arg1 >= numLeftCols)
+          || (arg0 >= numLeftCols && arg1 < numLeftCols)) {
+        Integer leftArg = 0;
+        Integer rightArg = 0;
+        if (arg0 < numLeftCols) {
+          // arg0 -> Left, arg1 -> Right
+          leftArg = arg0;
+          rightArg = arg1 - numLeftCols;
+        } else {
+          // arg0 -> Right, arg1 -> Left
+          leftArg = arg1;
+          rightArg = arg0 - numLeftCols;
+        }
+        boolean foundLeft = initLeftColumns.get(leftArg);
+        boolean foundRight = initRightColumns.get(rightArg);
+        if (foundLeft && !foundRight && !isOuterLeft) {
+          addedLeftCols.set(leftArg);
+        } else if (!foundLeft && foundRight && !isOuterRight) {
+          addedRightCols.set(rightArg);
+        }
+      }
+    }
+    final ImmutableBitSet leftColumns = initLeftColumns.union(addedLeftCols);
+    final ImmutableBitSet rightColumns = initRightColumns.union(addedRightCols);
 
     // If the original column mask contains columns from both the left and
     // right hand side, then the columns are unique if and only if they're
@@ -344,6 +386,35 @@ public class RelMdColumnUniqueness
     }
 
     throw new AssertionError();
+  }
+
+  /**
+   * Takes a RexNode that represents a condition and finas
+   * all equalities that are always True. This is used by Join
+   * to help identify when the columns are unique.
+   */
+  private HashSet<RexCall> findCommonEqualities(RexNode cond) {
+    // Note: Hash(RexNode) is equivalent to RexNode.toString().
+    HashSet<RexCall> equalityExprs = new HashSet<>();
+    if (cond.getKind() == SqlKind.EQUALS) {
+      equalityExprs.add((RexCall) cond);
+    } else if (cond.getKind() == SqlKind.AND) {
+      RexCall andCond = (RexCall) cond;
+      // And can have many children, we want to merge on
+      // all of them
+      for (RexNode operandCond : andCond.operands) {
+        equalityExprs.addAll(findCommonEqualities(operandCond));
+      }
+    } else if (cond.getKind() == SqlKind.OR) {
+      RexCall orCond = (RexCall) cond;
+      // Or can have many children, we only want to merge on nodes common to all of them
+      equalityExprs.addAll(findCommonEqualities(orCond.operands.get(0)));
+      for (int i = 1; i < orCond.operands.size(); i++) {
+        HashSet<RexCall> otherExprs = findCommonEqualities(orCond.operands.get(i));
+        equalityExprs.retainAll(otherExprs);
+      }
+    }
+    return equalityExprs;
   }
 
   public @Nullable Boolean areColumnsUnique(Aggregate rel, RelMetadataQuery mq,

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdColumnUniqueness.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdColumnUniqueness.java
@@ -319,8 +319,8 @@ public class RelMdColumnUniqueness
       // Left and right must not be in the same table
       if ((arg0 < numLeftCols && arg1 >= numLeftCols)
           || (arg0 >= numLeftCols && arg1 < numLeftCols)) {
-        Integer leftArg = 0;
-        Integer rightArg = 0;
+        Integer leftArg;
+        Integer rightArg;
         if (arg0 < numLeftCols) {
           // arg0 -> Left, arg1 -> Right
           leftArg = arg0;
@@ -397,7 +397,11 @@ public class RelMdColumnUniqueness
     // Note: Hash(RexNode) is equivalent to RexNode.toString().
     HashSet<RexCall> equalityExprs = new HashSet<>();
     if (cond.getKind() == SqlKind.EQUALS) {
-      equalityExprs.add((RexCall) cond);
+      RexCall equalNode = (RexCall) cond;
+      if (equalNode.getOperands().get(0) instanceof RexInputRef
+          && equalNode.getOperands().get(1) instanceof RexInputRef) {
+        equalityExprs.add(equalNode);
+      }
     } else if (cond.getKind() == SqlKind.AND) {
       RexCall andCond = (RexCall) cond;
       // And can have many children, we want to merge on

--- a/core/src/main/java/org/apache/calcite/rel/metadata/RelMdColumnUniqueness.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/RelMdColumnUniqueness.java
@@ -333,9 +333,9 @@ public class RelMdColumnUniqueness
         boolean foundLeft = initLeftColumns.get(leftArg);
         boolean foundRight = initRightColumns.get(rightArg);
         if (foundLeft && !foundRight && !isOuterLeft) {
-          addedLeftCols.set(leftArg);
-        } else if (!foundLeft && foundRight && !isOuterRight) {
           addedRightCols.set(rightArg);
+        } else if (!foundLeft && foundRight && !isOuterRight) {
+          addedLeftCols.set(leftArg);
         }
       }
     }

--- a/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
@@ -1029,7 +1029,9 @@ public class RelMetadataTest {
         .assertThatAreColumnsUnique(bitSetOf(0, 2), is(true))
         .assertThatAreColumnsUnique(bitSetOf(0, 1, 2), is(true))
         .assertThatAreColumnsUnique(bitSetOf(0, 2, 3), is(true))
-        .assertThatAreColumnsUnique(bitSetOf(0, 1), is(false));
+        .assertThatAreColumnsUnique(bitSetOf(0, 1), is(true))
+        .assertThatAreColumnsUnique(bitSetOf(1), is(false))
+        .assertThatAreColumnsUnique(bitSetOf(0), is(true));
   }
 
   @Test void testColumnUniquenessForAggregateWithConstantColumns() {

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -7591,7 +7591,7 @@ LogicalAggregate(group=[{2}])
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-LogicalAggregate(group=[{0}])
+LogicalProject(JOB=[$0])
   LogicalJoin(condition=[=($0, $1)], joinType=[right])
     LogicalAggregate(group=[{2}])
       LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
@@ -7834,7 +7834,7 @@ LogicalAggregate(group=[{10}])
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-LogicalAggregate(group=[{1}])
+LogicalProject(NAME=[$1])
   LogicalJoin(condition=[=($0, $1)], joinType=[left])
     LogicalAggregate(group=[{2}])
       LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])


### PR DESCRIPTION
Updates the uniqueness tests for join to include handling the other half of an inner join if it is a common equality condition. This is used to safely increase the size of the checked columns, which can match on additional primary keys.