### PR TITLE
[BE-3317] Define a constructor to add multiple default Schemas

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -700,7 +700,7 @@ allprojects {
                 }
             }
             configureEach<Test> {
-                outputs.cacheIf("test results depend on the database configuration, so we souldn't cache it") {
+                outputs.cacheIf("test results depend on the database configuration, so we shouldn't cache it") {
                     false
                 }
                 useJUnitPlatform {

--- a/core/src/main/java/org/apache/calcite/prepare/CalciteCatalogReader.java
+++ b/core/src/main/java/org/apache/calcite/prepare/CalciteCatalogReader.java
@@ -99,19 +99,24 @@ public class CalciteCatalogReader implements Prepare.CatalogReader {
 
 
   public CalciteCatalogReader(CalciteSchema rootSchema,
-      List<List<String>> defaultSchemas, RelDataTypeFactory typeFactory,
+      List<List<String>> defaultSchemas,
+      int numDefaults, // This field isn't needed but ensure the signatures are unique.
+      RelDataTypeFactory typeFactory,
       CalciteConnectionConfig config) {
     this(rootSchema, SqlNameMatchers.withCaseSensitive(config != null && config.caseSensitive()),
-        validateDefaultSchemaPaths(defaultSchemas), typeFactory, config);
+        validateDefaultSchemaPaths(defaultSchemas, numDefaults), typeFactory, config);
   }
 
   /**
    * Validate that each default schema provided is not null.
    * @param defaultSchemas List of provided schemas to serve as defaults.
+   * @param numDefaults Number of expected defaults. Used for an assert.
    * @return List of default schemas with an empty list appended as a sentinel.
    */
-  private static List<List<String>> validateDefaultSchemaPaths(List<List<String>> defaultSchemas) {
+  private static List<List<String>> validateDefaultSchemaPaths(List<List<String>> defaultSchemas,
+      int numDefaults) {
     List<List<String>> defaultSchemaPaths = new ArrayList<>();
+    assert numDefaults == defaultSchemas.size();
     for (List<String> defaultSchema: defaultSchemas) {
       defaultSchemaPaths.add(
           Objects.requireNonNull(defaultSchema, "defaultSchema"));

--- a/core/src/main/java/org/apache/calcite/prepare/CalciteCatalogReader.java
+++ b/core/src/main/java/org/apache/calcite/prepare/CalciteCatalogReader.java
@@ -97,6 +97,29 @@ public class CalciteCatalogReader implements Prepare.CatalogReader {
         typeFactory, config);
   }
 
+
+  public CalciteCatalogReader(CalciteSchema rootSchema,
+      List<List<String>> defaultSchemas, RelDataTypeFactory typeFactory,
+      CalciteConnectionConfig config) {
+    this(rootSchema, SqlNameMatchers.withCaseSensitive(config != null && config.caseSensitive()),
+        validateDefaultSchemaPaths(defaultSchemas), typeFactory, config);
+  }
+
+  /**
+   * Validate that each default schema provided is not null.
+   * @param defaultSchemas List of provided schemas to serve as defaults.
+   * @return List of default schemas with an empty list appended as a sentinel.
+   */
+  private static List<List<String>> validateDefaultSchemaPaths(List<List<String>> defaultSchemas) {
+    List<List<String>> defaultSchemaPaths = new ArrayList<>();
+    for (List<String> defaultSchema: defaultSchemas) {
+      defaultSchemaPaths.add(
+          Objects.requireNonNull(defaultSchema, "defaultSchema"));
+    }
+    defaultSchemaPaths.add(ImmutableList.of());
+    return defaultSchemaPaths;
+  }
+
   protected CalciteCatalogReader(CalciteSchema rootSchema,
       SqlNameMatcher nameMatcher, List<List<String>> schemaPaths,
       RelDataTypeFactory typeFactory, CalciteConnectionConfig config) {


### PR DESCRIPTION
Exposes a constructor so multiple schemas can be defined as default, searched in the order in which they were provided.