### PR TITLE
[BE-4150] Support for using a string literal in Interval Literals

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -4902,10 +4902,18 @@ SqlLiteral IntervalLiteral() :
         <PLUS> { sign = 1; }
     ]
     <QUOTED_STRING> { p = token.image; }
-    intervalQualifier = IntervalQualifier() {
-        return SqlParserUtil.parseIntervalLiteral(s.end(intervalQualifier),
-            sign, p, intervalQualifier);
-    }
+    (
+        intervalQualifier = IntervalQualifier() {
+            return SqlParserUtil.parseIntervalLiteral(s.end(intervalQualifier),
+                sign, p, intervalQualifier);
+        }
+    |
+        {
+            return SqlParserUtil.parseSnowflakeIntervalLiteral(s.end(this), sign, p);
+        }
+    )
+
+
 }
 
 /** Parses an interval literal (e.g. {@code INTERVAL '2:3' HOUR TO MINUTE})
@@ -4929,10 +4937,16 @@ SqlNode IntervalLiteralOrExpression() :
     (
         // literal (with quoted string)
         <QUOTED_STRING> { p = token.image; }
-        intervalQualifier = IntervalQualifier() {
-            return SqlParserUtil.parseIntervalLiteral(s.end(intervalQualifier),
-                sign, p, intervalQualifier);
-        }
+        (
+            intervalQualifier = IntervalQualifier() {
+                return SqlParserUtil.parseIntervalLiteral(s.end(intervalQualifier),
+                    sign, p, intervalQualifier);
+            }
+        |
+           {
+                return SqlParserUtil.parseSnowflakeIntervalLiteral(s.end(this), sign, p);
+           }
+        )
     |
         // To keep parsing simple, any expressions besides numeric literal and
         // identifiers must be enclosed in parentheses.

--- a/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
+++ b/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
@@ -67,6 +67,9 @@ public interface CalciteResource {
   @Property(name = "SQLSTATE", value = "42000")
   ExInst<CalciteException> illegalIntervalLiteral(String a0, String a1);
 
+  @BaseMessage("Unsupported Snowflake style INTERVAL literal {0}; at {1}. Commas are not supported yet in interval literals")
+  ExInst<CalciteException> unsupportedSnowflakeIntervalLiteral(String a0, String a1);
+
   @BaseMessage("Illegal expression. Was expecting \"(DATETIME - DATETIME) INTERVALQUALIFIER\"")
   ExInst<CalciteException> illegalMinusDate();
 

--- a/core/src/main/java/org/apache/calcite/sql/parser/SqlParserUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/parser/SqlParserUtil.java
@@ -237,6 +237,7 @@ public final class SqlParserUtil {
         final String timeUnitStr;
         if (intervalParts.length == 1) {
           // If we have only 1 part then it may not be space separated (rare but possible).
+          // For example: Interval '30d'.
           // If we so we look for the first non-numeric character and split on that.
           int endIdx = -1;
           final String baseStr = intervalParts[0];

--- a/core/src/main/resources/org/apache/calcite/runtime/CalciteResource.properties
+++ b/core/src/main/resources/org/apache/calcite/runtime/CalciteResource.properties
@@ -30,6 +30,7 @@ BadFormat=not in format ''{0}''
 BetweenWithoutAnd=BETWEEN operator has no terminating AND
 GeometryDisabled=Geo-spatial extensions and the GEOMETRY data type are not enabled
 IllegalIntervalLiteral=Illegal INTERVAL literal {0}; at {1}
+UnsupportedSnowflakeIntervalLiteral=Unsupported Snowflake style INTERVAL literal {0}; at {1}. Commas are not supported yet in interval literals
 IllegalMinusDate=Illegal expression. Was expecting "(DATETIME - DATETIME) INTERVALQUALIFIER"
 IllegalOverlaps=Illegal overlaps expression. Was expecting expression on the form "(DATETIME, EXPRESSION) OVERLAPS (DATETIME, EXPRESSION)"
 IllegalNonQueryExpression=Non-query expression encountered in illegal context

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -2885,28 +2885,77 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         .columnType("INTERVAL YEAR NOT NULL");
     expr("INTERVAL '1 YEARS'")
         .columnType("INTERVAL YEAR NOT NULL");
+    expr("INTERVAL '1 y'")
+        .columnType("INTERVAL YEAR NOT NULL");
+    expr("INTERVAL '1 yy'")
+        .columnType("INTERVAL YEAR NOT NULL");
+    expr("INTERVAL '1 yyy'")
+        .columnType("INTERVAL YEAR NOT NULL");
+    expr("INTERVAL '1 yyyy'")
+        .columnType("INTERVAL YEAR NOT NULL");
+    expr("INTERVAL '1 yr'")
+        .columnType("INTERVAL YEAR NOT NULL");
+    expr("INTERVAL '1 yrs'")
+        .columnType("INTERVAL YEAR NOT NULL");
     expr("-INTERVAL '5 MONTH'")
         .columnType("INTERVAL MONTH NOT NULL");
     expr("+INTERVAL '3 MONTHS'")
+        .columnType("INTERVAL MONTH NOT NULL");
+    expr("-INTERVAL '5 mm'")
+        .columnType("INTERVAL MONTH NOT NULL");
+    expr("+INTERVAL '3 mon'")
+        .columnType("INTERVAL MONTH NOT NULL");
+    expr("+INTERVAL '3 mons'")
         .columnType("INTERVAL MONTH NOT NULL");
     expr("INTERVAL '1 DAY'")
         .columnType("INTERVAL DAY NOT NULL");
     expr("INTERVAL '1 DAYS'")
         .columnType("INTERVAL DAY NOT NULL");
+    expr("INTERVAL '1 d'")
+        .columnType("INTERVAL DAY NOT NULL");
+    expr("INTERVAL '1 dd'")
+        .columnType("INTERVAL DAY NOT NULL");
+    expr("INTERVAL '1 dayofmonth'")
+        .columnType("INTERVAL DAY NOT NULL");
     expr("INTERVAL '1 HOUR'")
         .columnType("INTERVAL HOUR NOT NULL");
     expr("INTERVAL '1 HOURS'")
+        .columnType("INTERVAL HOUR NOT NULL");
+    expr("INTERVAL '1 hrs'")
+        .columnType("INTERVAL HOUR NOT NULL");
+    expr("INTERVAL '1 h'")
+        .columnType("INTERVAL HOUR NOT NULL");
+    expr("INTERVAL '1 hh'")
+        .columnType("INTERVAL HOUR NOT NULL");
+    expr("INTERVAL '1 hr'")
         .columnType("INTERVAL HOUR NOT NULL");
     expr("-INTERVAL '5 MINUTE'")
         .columnType("INTERVAL MINUTE NOT NULL");
     expr("+INTERVAL '3 MINUTES'")
         .columnType("INTERVAL MINUTE NOT NULL");
+    expr("-INTERVAL '5 m'")
+        .columnType("INTERVAL MINUTE NOT NULL");
+    expr("+INTERVAL '3 mi'")
+        .columnType("INTERVAL MINUTE NOT NULL");
+    expr("-INTERVAL '5 min'")
+        .columnType("INTERVAL MINUTE NOT NULL");
+    expr("+INTERVAL '3 mins'")
+        .columnType("INTERVAL MINUTE NOT NULL");
     expr("INTERVAL '1 SECOND'")
         .columnType("INTERVAL SECOND NOT NULL");
     expr("INTERVAL '1 SECONDS'")
         .columnType("INTERVAL SECOND NOT NULL");
+    expr("INTERVAL '1 sec'")
+        .columnType("INTERVAL SECOND NOT NULL");
+    expr("INTERVAL '1 s'")
+        .columnType("INTERVAL SECOND NOT NULL");
+    expr("INTERVAL '1 secs'")
+        .columnType("INTERVAL SECOND NOT NULL");
     // Test multiple spaces
     expr("INTERVAL '1    SECOND'")
+        .columnType("INTERVAL SECOND NOT NULL");
+    // Test no space
+    expr("INTERVAL '1SECOND'")
         .columnType("INTERVAL SECOND NOT NULL");
     // Test defaults
     expr("-INTERVAL '5 '")

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -2876,6 +2876,47 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
   }
 
   /**
+   * Test generating an interval literal in Snowflake syntax where
+   * a literal has multiple comma separated values. This should parse
+   * but raise an exception
+   */
+  void subTestIntervalStringLiterals() {
+    expr("INTERVAL '1 Year'")
+        .columnType("INTERVAL YEAR NOT NULL");
+    expr("INTERVAL '1 YEARS'")
+        .columnType("INTERVAL YEAR NOT NULL");
+    expr("-INTERVAL '5 MONTH'")
+        .columnType("INTERVAL MONTH NOT NULL");
+    expr("+INTERVAL '3 MONTHS'")
+        .columnType("INTERVAL MONTH NOT NULL");
+    expr("INTERVAL '1 DAY'")
+        .columnType("INTERVAL DAY NOT NULL");
+    expr("INTERVAL '1 DAYS'")
+        .columnType("INTERVAL DAY NOT NULL");
+    expr("INTERVAL '1 HOUR'")
+        .columnType("INTERVAL HOUR NOT NULL");
+    expr("INTERVAL '1 HOURS'")
+        .columnType("INTERVAL HOUR NOT NULL");
+    expr("-INTERVAL '5 MINUTE'")
+        .columnType("INTERVAL MINUTE NOT NULL");
+    expr("+INTERVAL '3 MINUTES'")
+        .columnType("INTERVAL MINUTE NOT NULL");
+    expr("INTERVAL '1 SECOND'")
+        .columnType("INTERVAL SECOND NOT NULL");
+    expr("INTERVAL '1 SECONDS'")
+        .columnType("INTERVAL SECOND NOT NULL");
+    // Test multiple spaces
+    expr("INTERVAL '1    SECOND'")
+        .columnType("INTERVAL SECOND NOT NULL");
+    // Test defaults
+    expr("-INTERVAL '5 '")
+        .columnType("INTERVAL SECOND NOT NULL");
+    expr("INTERVAL '3'")
+        .columnType("INTERVAL SECOND NOT NULL");
+
+  }
+
+  /**
    * Runs tests for INTERVAL... YEAR that should pass parser but fail
    * validator. A substantially identical set of tests exists in
    * SqlParserTest, and any changes here should be synchronized there.
@@ -3833,6 +3874,24 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
             + " INTERVAL SECOND\\(1, 0\\)");
   }
 
+  /**
+   * Test generating an interval literal in Snowflake syntax where
+   * the entire literal is delimited in quotes. This tests the comma
+   * syntax, which is not yet supported.
+   */
+  void subTestIntervalStringLiteralComma() {
+    expr("^INTERVAL '1 Year, 1 Month'^").fails(
+        "Unsupported Snowflake style INTERVAL literal '1 Year, 1 Month'; at line 1, column 9. Commas are not supported yet in interval literals"
+    );
+    // Test default
+    expr("-^INTERVAL '5, 1 month'^").fails(
+        "Unsupported Snowflake style INTERVAL literal '5, 1 month'; at line 1, column 10. Commas are not supported yet in interval literals"
+    );
+    expr("^INTERVAL '3, 4 Days'^").fails(
+        "Unsupported Snowflake style INTERVAL literal '3, 4 Days'; at line 1, column 9. Commas are not supported yet in interval literals"
+    );
+  }
+
   @Test void testDatetimePlusNullInterval() {
     expr("TIME '8:8:8' + cast(NULL AS interval hour)").columnType("TIME(0)");
     expr("TIME '8:8:8' + cast(NULL AS interval YEAR)").columnType("TIME(0)");
@@ -3879,6 +3938,7 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     subTestIntervalMinutePositive();
     subTestIntervalMinuteToSecondPositive();
     subTestIntervalSecondPositive();
+    subTestIntervalStringLiterals();
 
     // Tests that should pass parser but fail validator
     subTestIntervalYearNegative();
@@ -3894,6 +3954,7 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     subTestIntervalMinuteNegative();
     subTestIntervalMinuteToSecondNegative();
     subTestIntervalSecondNegative();
+    subTestIntervalStringLiteralComma();
 
     // Miscellaneous
     // fractional value is not OK, even if it is 0

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -2877,8 +2877,7 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
 
   /**
    * Test generating an interval literal in Snowflake syntax where
-   * a literal has multiple comma separated values. This should parse
-   * but raise an exception
+   * a literal and its unit are inside the quoted string.
    */
   void subTestIntervalStringLiterals() {
     expr("INTERVAL '1 Year'")

--- a/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -7144,24 +7144,6 @@ public class SqlParserTest {
   }
 
   @Test void testUnparseableIntervalQualifiers() {
-    // No qualifier
-    expr("interval '1^'^")
-        .fails("Encountered \"<EOF>\" at line 1, column 12\\.\n"
-            + "Was expecting one of:\n"
-            + "    \"DAY\" \\.\\.\\.\n"
-            + "    \"DAYS\" \\.\\.\\.\n"
-            + "    \"HOUR\" \\.\\.\\.\n"
-            + "    \"HOURS\" \\.\\.\\.\n"
-            + "    \"MINUTE\" \\.\\.\\.\n"
-            + "    \"MINUTES\" \\.\\.\\.\n"
-            + "    \"MONTH\" \\.\\.\\.\n"
-            + "    \"MONTHS\" \\.\\.\\.\n"
-            + "    \"SECOND\" \\.\\.\\.\n"
-            + "    \"SECONDS\" \\.\\.\\.\n"
-            + "    \"YEAR\" \\.\\.\\.\n"
-            + "    \"YEARS\" \\.\\.\\.\n"
-            + "    ");
-
     // illegal qualifiers, no precision in either field
     expr("interval '1' year ^to^ year")
         .fails("(?s)Encountered \"to year\" at line 1, column 19.\n"
@@ -7611,8 +7593,8 @@ public class SqlParserTest {
         .ok("INTERVAL -'1' DAY");
     expr("interval '-1' day")
         .ok("INTERVAL '-1' DAY");
-    expr("interval 'wael was here^'^")
-        .fails("(?s)Encountered \"<EOF>\".*");
+    expr("^interval 'wael was here'^")
+        .fails("Illegal INTERVAL literal 'wael was here'.*");
 
     // ok in parser, not in validator
     expr("interval 'wael was here' HOUR")

--- a/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -7498,7 +7498,7 @@ public class SqlParserTest {
     // Invalid units
     expr("INTERVAL '2' ^MILLENNIUM^")
         .fails(ANY);
-    expr("INTERVAL '1-2' ^MILLENNIUM^ TO CENTURY")
+    expr("^INTERVAL '1-2'^ MILLENNIUM TO CENTURY")
         .fails(ANY);
     expr("INTERVAL '10' ^CENTURY^")
         .fails(ANY);


### PR DESCRIPTION
Adds support for using a string literal in the SQL interval that contains both interval amount and the unit https://docs.snowflake.com/en/sql-reference/data-types-datetime.html#interval-constants. This adds support for the intervals that are already supported but doesn't add new intervals.