### PR TITLE
[BE-4135] LEAST string->timestamp cast support

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -213,7 +213,7 @@ public abstract class SqlLibraryOperators {
   @LibraryOperator(libraries = {ORACLE})
   public static final SqlFunction LEAST =
       new SqlFunction("LEAST", SqlKind.LEAST,
-          ReturnTypes.ARG0,
+          ReturnTypes.LEAST_RESTRICTIVE.andThen(SqlTypeTransforms.TO_NULLABLE),
           null, OperandTypes.SAME_VARIADIC, SqlFunctionCategory.SYSTEM);
 
   /**

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -213,8 +213,8 @@ public abstract class SqlLibraryOperators {
   @LibraryOperator(libraries = {ORACLE})
   public static final SqlFunction LEAST =
       new SqlFunction("LEAST", SqlKind.LEAST,
-          ReturnTypes.LEAST_RESTRICTIVE.andThen(SqlTypeTransforms.TO_NULLABLE),
-          null, OperandTypes.SAME_VARIADIC, SqlFunctionCategory.SYSTEM);
+          ReturnTypes.ARG0,
+          null, OperandTypes.VARIADIC, SqlFunctionCategory.SYSTEM);
 
   /**
    * The <code>TRANSLATE(<i>string_expr</i>, <i>search_chars</i>,

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -214,7 +214,7 @@ public abstract class SqlLibraryOperators {
   public static final SqlFunction LEAST =
       new SqlFunction("LEAST", SqlKind.LEAST,
           ReturnTypes.ARG0,
-          null, OperandTypes.VARIADIC, SqlFunctionCategory.SYSTEM);
+          null, OperandTypes.SAME_VARIADIC, SqlFunctionCategory.SYSTEM);
 
   /**
    * The <code>TRANSLATE(<i>string_expr</i>, <i>search_chars</i>,

--- a/core/src/main/java/org/apache/calcite/sql2rel/StandardConvertletTable.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/StandardConvertletTable.java
@@ -1638,7 +1638,7 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
         throw new AssertionError();
       }
       final List<RexNode> exprs =
-          convertOperands(cx, call, SqlOperandTypeChecker.Consistency.NONE);
+          convertOperands(cx, call, SqlOperandTypeChecker.Consistency.COMPARE);
       final List<RexNode> list = new ArrayList<>();
       final List<RexNode> orList = new ArrayList<>();
       for (RexNode expr : exprs) {

--- a/core/src/main/java/org/apache/calcite/sql2rel/StandardConvertletTable.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/StandardConvertletTable.java
@@ -1638,7 +1638,7 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
         throw new AssertionError();
       }
       final List<RexNode> exprs =
-          convertOperands(cx, call, SqlOperandTypeChecker.Consistency.COMPARE);
+          convertOperands(cx, call, SqlOperandTypeChecker.Consistency.NONE);
       final List<RexNode> list = new ArrayList<>();
       final List<RexNode> orList = new ArrayList<>();
       for (RexNode expr : exprs) {


### PR DESCRIPTION
Changing `Consistency.None` to `Consistency.COMPARE` for `GreatestConvertlet` allows for Calcite to generate a plan with a cast to Timestamp type for valid types (e.g. String columns).