### PR TITLE
[BE-2457] Adds additional support for implicite conversions between tz aware types

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlTzAwareTypeNameSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlTzAwareTypeNameSpec.java
@@ -33,7 +33,7 @@ public class SqlTzAwareTypeNameSpec extends SqlTypeNameSpec {
 
   public final BodoTZInfo origTz;
 
-  
+
   /**
    * Creates a {@code SqlTzAwareTypeNameSpec} from an existing TZAwareSqlType.
    *

--- a/core/src/main/java/org/apache/calcite/sql/SqlTzAwareTypeNameSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlTzAwareTypeNameSpec.java
@@ -23,6 +23,8 @@ import org.apache.calcite.sql.type.TZAwareSqlType;
 import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.util.Litmus;
 
+import java.util.Objects;
+
 /**
  * A sql type name specification of a timezone aware sql type.
  *
@@ -31,15 +33,28 @@ public class SqlTzAwareTypeNameSpec extends SqlTypeNameSpec {
 
   public final BodoTZInfo origTz;
 
+  
   /**
-   * Creates a {@code SqlTypeNameSpec}.
+   * Creates a {@code SqlTzAwareTypeNameSpec} from an existing TZAwareSqlType.
    *
-   * @param name Name of the type
-   * @param pos  Parser position, must not be null
+   * @param type The TZAwareSqlType
    */
   public SqlTzAwareTypeNameSpec(final TZAwareSqlType type) {
-    super(type.getSqlIdentifier(), SqlParserPos.ZERO);
+    super(Objects.requireNonNull(type.getSqlIdentifier()), SqlParserPos.ZERO);
     this.origTz = type.getTZInfo();
+  }
+
+
+  /**
+   * Creates a {@code SqlTzAwareTypeNameSpec}.
+   *
+   * @param name Name of the type, must not be null
+   * @param info TzInfo of the type, must not be null
+   * @param pos  Parser position, must not be null
+   */
+  SqlTzAwareTypeNameSpec(SqlIdentifier name, BodoTZInfo info, SqlParserPos pos) {
+    super(name, pos);
+    this.origTz = info;
   }
 
   @Override public RelDataType deriveType(final SqlValidator validator) {

--- a/core/src/main/java/org/apache/calcite/sql/SqlTzAwareTypeNameSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlTzAwareTypeNameSpec.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.type.BodoTZInfo;
+import org.apache.calcite.sql.type.TZAwareSqlType;
+import org.apache.calcite.sql.validate.SqlValidator;
+import org.apache.calcite.util.Litmus;
+
+/**
+ * A sql type name specification of a timezone aware sql type.
+ *
+ */
+public class SqlTzAwareTypeNameSpec extends SqlTypeNameSpec {
+
+  public final BodoTZInfo origTz;
+
+  /**
+   * Creates a {@code SqlTypeNameSpec}.
+   *
+   * @param name Name of the type
+   * @param pos  Parser position, must not be null
+   */
+  public SqlTzAwareTypeNameSpec(final TZAwareSqlType type) {
+    super(type.getSqlIdentifier(), SqlParserPos.ZERO);
+    this.origTz = type.getTZInfo();
+  }
+
+  @Override public RelDataType deriveType(final SqlValidator validator) {
+    return validator.getTypeFactory().createTZAwareSqlType(origTz);
+  }
+
+  @Override public void unparse(final SqlWriter writer, final int leftPrec, final int rightPrec) {
+    writer.keyword("TIMESTAMP(" + this.origTz.getPyZone() + ")");
+  }
+
+  @Override public boolean equalsDeep(final SqlTypeNameSpec spec, final Litmus litmus) {
+    if (!(spec instanceof SqlTzAwareTypeNameSpec)) {
+      return false;
+    }
+    return this.origTz == ((SqlTzAwareTypeNameSpec) spec).origTz;
+  }
+
+}

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeUtil.java
@@ -33,6 +33,7 @@ import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlRowTypeNameSpec;
 import org.apache.calcite.sql.SqlTypeNameSpec;
+import org.apache.calcite.sql.SqlTzAwareTypeNameSpec;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.validate.SqlNameMatcher;
 import org.apache.calcite.sql.validate.SqlValidator;
@@ -1036,7 +1037,10 @@ public abstract class SqlTypeUtil {
     assert typeName != null;
 
     final SqlTypeNameSpec typeNameSpec;
-    if (isAtomic(type) || isNull(type) || type.getSqlTypeName() == SqlTypeName.UNKNOWN) {
+
+    if (type instanceof TZAwareSqlType) {
+      typeNameSpec = new SqlTzAwareTypeNameSpec((TZAwareSqlType) type);
+    } else if (isAtomic(type) || isNull(type) || type.getSqlTypeName() == SqlTypeName.UNKNOWN) {
       int precision = typeName.allowsPrec() ? type.getPrecision() : -1;
       // fix up the precision.
       if (maxPrecision > 0 && precision > maxPrecision) {

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -993,6 +993,15 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
     sql(sql).ok();
   }
 
+  /**
+   * Test casting to a TZ_Aware type implicitly.
+   */
+  @Test void testImplicitCastTimestamp() {
+    String sql = "Select ename from emp WHERE\n"
+        + "CURRENT_TIMESTAMP BETWEEN DATE '2022-1-1' AND DATE '2023-12-25'";
+    sql(sql).ok();
+  }
+
   /** As {@link #testSelectOverDistinct()} but for streaming queries. */
   @Test void testSelectStreamPartitionDistinct() {
     final String sql = "select stream\n"

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -2796,6 +2796,15 @@ LogicalProject(DEPTNO=[$7])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testImplicitCastTimestamp">
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(ENAME=[$1])
+  LogicalFilter(condition=[AND(>=(CURRENT_TIMESTAMP, CAST(2022-01-01):TIMESTAMP('UTC') NOT NULL), <=(CURRENT_TIMESTAMP, CAST(2023-12-25):TIMESTAMP('UTC') NOT NULL))])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testImplicitJoinExpandAndDecorrelation">
     <Resource name="planExpanded">
       <![CDATA[
@@ -7059,17 +7068,18 @@ LogicalProject(CURRENT_TIMESTAMP=[CURRENT_TIMESTAMP])
   LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
     </Resource>
-  </TestCase><TestCase name="testSelectCurrentTimestampIntervalWeek">
-  <Resource name="sql">
-    <![CDATA[select CURRENT_TIMESTAMP + INTERVAL '5 WEEKS' from emp]]>
-  </Resource>
-  <Resource name="plan">
-    <![CDATA[
+  </TestCase>
+  <TestCase name="testSelectCurrentTimestampIntervalWeek">
+    <Resource name="sql">
+      <![CDATA[select CURRENT_TIMESTAMP + INTERVAL '5 WEEKS' from emp]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
 LogicalProject(EXPR$0=[+(CURRENT_TIMESTAMP, 3024000000:INTERVAL WEEK)])
   LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
-  </Resource>
-</TestCase>
+    </Resource>
+  </TestCase>
   <TestCase name="testSelectCurrentTimestampIntervalWeekSF">
     <Resource name="sql">
       <![CDATA[select CURRENT_TIMESTAMP + INTERVAL '8' WEEKS from emp]]>


### PR DESCRIPTION
Adds an SqlTxAwareTypeNameSpec, which is a SqlTypeNameSpec for our tz aware sql type. This ensures that Calcite properly handles cases where we implicitly cast to our tz aware type. This was needed for the Apple usecase.