### PR TITLE
Add support for configuring the literal type

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeSystem.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeSystem.java
@@ -419,4 +419,12 @@ public interface RelDataTypeSystem {
     return BodoTZInfo.UTC;
   }
 
+  /**
+   * Get the default SQLTypeName used for the type of SQL Literals.
+   * This should be either CHAR, VARCHAR, or an equivalent string type.
+   * @return
+   */
+  default SqlTypeName getCharLiteralTypeName() {
+    return SqlTypeName.CHAR;
+  }
 }

--- a/core/src/main/java/org/apache/calcite/sql/SqlUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlUtil.java
@@ -989,9 +989,10 @@ public abstract class SqlUtil {
     if (null == collation) {
       collation = SqlCollation.COERCIBLE;
     }
+    SqlTypeName typeName = typeFactory.getTypeSystem().getCharLiteralTypeName();
     RelDataType type =
         typeFactory.createSqlType(
-            SqlTypeName.CHAR,
+            typeName,
             str.getValue().length());
     type =
         typeFactory.createTypeWithCharsetAndCollation(


### PR DESCRIPTION
Enable specifying string literals are varchar to avoid casts.