### PR TITLE
Support propagating typesystem info to Interval Literals

### DIFF
--- a/core/src/main/java/org/apache/calcite/rex/RexLiteral.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexLiteral.java
@@ -24,6 +24,7 @@ import org.apache.calcite.linq4j.function.Functions;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rel.type.RelDataTypeSystem;
 import org.apache.calcite.runtime.FlatLists;
 import org.apache.calcite.runtime.GeoFunctions;
 import org.apache.calcite.runtime.Geometries;
@@ -793,6 +794,9 @@ public class RexLiteral extends RexNode {
       return null;
     }
 
+    // We don't have a type system yet so use the default
+    RelDataTypeSystem typeSystem = RelDataTypeSystem.DEFAULT;
+
     switch (typeName) {
     case CHAR:
       Charset charset = requireNonNull(type.getCharset(), () -> "charset for " + type);
@@ -819,7 +823,8 @@ public class RexLiteral extends RexNode {
       long weekMillis =
           SqlParserUtil.intervalToMillis(
               literal,
-              castNonNull(type.getIntervalQualifier()));
+              castNonNull(type.getIntervalQualifier()),
+              typeSystem);
       return new RexLiteral(BigDecimal.valueOf(weekMillis), type, typeName);
     case INTERVAL_DAY:
     case INTERVAL_DAY_HOUR:
@@ -834,7 +839,8 @@ public class RexLiteral extends RexNode {
       long millis =
           SqlParserUtil.intervalToMillis(
               literal,
-              castNonNull(type.getIntervalQualifier()));
+              castNonNull(type.getIntervalQualifier()),
+              typeSystem);
       return new RexLiteral(BigDecimal.valueOf(millis), type, typeName);
     case INTERVAL_YEAR:
     case INTERVAL_YEAR_MONTH:
@@ -842,7 +848,8 @@ public class RexLiteral extends RexNode {
       long months =
           SqlParserUtil.intervalToMonths(
               literal,
-              castNonNull(type.getIntervalQualifier()));
+              castNonNull(type.getIntervalQualifier()),
+              typeSystem);
       return new RexLiteral(BigDecimal.valueOf(months), type, typeName);
     case DATE:
     case TIME:

--- a/core/src/main/java/org/apache/calcite/sql/SqlLiteral.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlLiteral.java
@@ -20,6 +20,7 @@ import org.apache.calcite.avatica.util.TimeUnitRange;
 import org.apache.calcite.rel.metadata.NullSentinel;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeSystem;
 import org.apache.calcite.sql.fun.SqlLiteralChainOperator;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParserPos;
@@ -288,6 +289,9 @@ public class SqlLiteral extends SqlNode {
    * @throws AssertionError if the value type is not supported
    */
   public <T extends Object> T getValueAs(Class<T> clazz) {
+    return getValueAs(clazz, RelDataTypeSystem.DEFAULT)
+  }
+  public <T extends Object> T getValueAs(Class<T> clazz, RelDataTypeSystem typeSystem) {
     Object value = this.value;
     if (clazz.isInstance(value)) {
       return clazz.cast(value);
@@ -355,7 +359,7 @@ public class SqlLiteral extends SqlNode {
           (SqlIntervalLiteral.IntervalValue) value;
       if (clazz == Long.class) {
         return clazz.cast(valMonth.getSign()
-            * SqlParserUtil.intervalToMonths(valMonth));
+            * SqlParserUtil.intervalToMonths(valMonth, typeSystem));
       } else if (clazz == BigDecimal.class) {
         return clazz.cast(BigDecimal.valueOf(getValueAs(Long.class)));
       } else if (clazz == TimeUnitRange.class) {
@@ -379,7 +383,7 @@ public class SqlLiteral extends SqlNode {
           (SqlIntervalLiteral.IntervalValue) value;
       if (clazz == Long.class) {
         return clazz.cast(valTime.getSign()
-            * SqlParserUtil.intervalToMillis(valTime));
+            * SqlParserUtil.intervalToMillis(valTime, typeSystem));
       } else if (clazz == BigDecimal.class) {
         return clazz.cast(BigDecimal.valueOf(getValueAs(Long.class)));
       } else if (clazz == TimeUnitRange.class) {
@@ -447,6 +451,8 @@ public class SqlLiteral extends SqlNode {
    */
   public static @Nullable Comparable value(SqlNode node)
       throws IllegalArgumentException {
+    // We don't have typeSystem information so we use the default.
+    RelDataTypeSystem typeSystem = RelDataTypeSystem.DEFAULT;
     if (node instanceof SqlLiteral) {
       final SqlLiteral literal = (SqlLiteral) node;
       if (literal.getTypeName() == SqlTypeName.SYMBOL) {
@@ -461,11 +467,11 @@ public class SqlLiteral extends SqlNode {
       case INTERVAL_YEAR_MONTH:
         final SqlIntervalLiteral.IntervalValue valMonth =
             literal.getValueAs(SqlIntervalLiteral.IntervalValue.class);
-        return valMonth.getSign() * SqlParserUtil.intervalToMonths(valMonth);
+        return valMonth.getSign() * SqlParserUtil.intervalToMonths(valMonth, typeSystem);
       case INTERVAL_DAY_TIME:
         final SqlIntervalLiteral.IntervalValue valTime =
             literal.getValueAs(SqlIntervalLiteral.IntervalValue.class);
-        return valTime.getSign() * SqlParserUtil.intervalToMillis(valTime);
+        return valTime.getSign() * SqlParserUtil.intervalToMillis(valTime, typeSystem);
       default:
         break;
       }

--- a/core/src/main/java/org/apache/calcite/sql/SqlLiteral.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlLiteral.java
@@ -289,7 +289,7 @@ public class SqlLiteral extends SqlNode {
    * @throws AssertionError if the value type is not supported
    */
   public <T extends Object> T getValueAs(Class<T> clazz) {
-    return getValueAs(clazz, RelDataTypeSystem.DEFAULT)
+    return getValueAs(clazz, RelDataTypeSystem.DEFAULT);
   }
   public <T extends Object> T getValueAs(Class<T> clazz, RelDataTypeSystem typeSystem) {
     Object value = this.value;

--- a/core/src/main/java/org/apache/calcite/sql/parser/SqlParserUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/parser/SqlParserUtil.java
@@ -356,21 +356,22 @@ public final class SqlParserUtil {
    * interval value.
    */
   public static long intervalToMillis(
-      SqlIntervalLiteral.IntervalValue interval) {
+      SqlIntervalLiteral.IntervalValue interval, RelDataTypeSystem typeSystem) {
     return intervalToMillis(
         interval.getIntervalLiteral(),
-        interval.getIntervalQualifier());
+        interval.getIntervalQualifier(),
+        typeSystem);
   }
 
   public static long intervalToMillis(
       String literal,
-      SqlIntervalQualifier intervalQualifier) {
+      SqlIntervalQualifier intervalQualifier, RelDataTypeSystem typeSystem) {
     Preconditions.checkArgument(!intervalQualifier.isYearMonth(),
         "interval must be day time");
     int[] ret;
     try {
       ret = intervalQualifier.evaluateIntervalLiteral(literal,
-          intervalQualifier.getParserPosition(), RelDataTypeSystem.DEFAULT);
+          intervalQualifier.getParserPosition(), typeSystem);
       assert ret != null;
     } catch (CalciteContextException e) {
       throw new RuntimeException("while parsing day-to-second interval "
@@ -403,21 +404,23 @@ public final class SqlParserUtil {
    * value.
    */
   public static long intervalToMonths(
-      SqlIntervalLiteral.IntervalValue interval) {
+      SqlIntervalLiteral.IntervalValue interval, RelDataTypeSystem typeSystem) {
     return intervalToMonths(
         interval.getIntervalLiteral(),
-        interval.getIntervalQualifier());
+        interval.getIntervalQualifier(),
+        typeSystem);
   }
 
   public static long intervalToMonths(
       String literal,
-      SqlIntervalQualifier intervalQualifier) {
+      SqlIntervalQualifier intervalQualifier,
+      RelDataTypeSystem typeSystem) {
     Preconditions.checkArgument(intervalQualifier.isYearMonth(),
         "interval must be year month");
     int[] ret;
     try {
       ret = intervalQualifier.evaluateIntervalLiteral(literal,
-          intervalQualifier.getParserPosition(), RelDataTypeSystem.DEFAULT);
+          intervalQualifier.getParserPosition(), typeSystem);
       assert ret != null;
     } catch (CalciteContextException e) {
       throw new RuntimeException("Error while parsing year-to-month interval "

--- a/testkit/src/main/java/org/apache/calcite/test/SqlValidatorFixture.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlValidatorFixture.java
@@ -22,6 +22,7 @@ import org.apache.calcite.config.CalciteConnectionProperty;
 import org.apache.calcite.config.Lex;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rel.type.RelDataTypeSystem;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCollation;
 import org.apache.calcite.sql.SqlIntervalLiteral;
@@ -340,15 +341,16 @@ public class SqlValidatorFixture {
             }
           }
 
+          RelDataTypeSystem typeSystem = factory.getTypeFactory().getTypeSystem();
           assertNotNull(node);
           SqlIntervalLiteral intervalLiteral = (SqlIntervalLiteral) node;
           SqlIntervalLiteral.IntervalValue interval =
               intervalLiteral.getValueAs(
-                  SqlIntervalLiteral.IntervalValue.class);
+                  SqlIntervalLiteral.IntervalValue.class, typeSystem);
           long l =
               interval.getIntervalQualifier().isYearMonth()
-                  ? SqlParserUtil.intervalToMonths(interval)
-                  : SqlParserUtil.intervalToMillis(interval);
+                  ? SqlParserUtil.intervalToMonths(interval, typeSystem)
+                  : SqlParserUtil.intervalToMillis(interval, typeSystem);
           assertThat(l, matcher);
         });
   }


### PR DESCRIPTION
Fixes SqlToRel for interval literals to use the same typesystem as validation rather than the default.