### PR TITLE
Prevent subqueries from being marked as constant expressions

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/ReduceExpressionsRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/ReduceExpressionsRule.java
@@ -1087,7 +1087,9 @@ public abstract class ReduceExpressionsRule<C extends ReduceExpressionsRule.Conf
     }
 
     @Override public Void visitSubQuery(RexSubQuery subQuery) {
-      analyzeCall(subQuery, Constancy.REDUCIBLE_CONSTANT);
+      // subqueries are never reducible
+      // must be expanded by another planner rule to something else
+      analyzeCall(subQuery, Constancy.IRREDUCIBLE_CONSTANT);
       return null;
     }
 


### PR DESCRIPTION
Subqueries were being marked as constant expressions by the
`ReduceExpressionsRule`. This is because subqueries are call expressions
with their own arguments. Call expressions are assumed to be reducible
if all of their arguments are reducible. The problem is that subqueries
weren't considering the subquery relation when determining if the call
was reducible.

While it might be possible for some subqueries to be constants and
reducible, that would only apply to things like a `LogicalValues` node
and it would be better if that were handled by other planner rules. This
change updates the `analyzeCall` method to mark all subqueries as
irreducible. Their arguments, if any, will still be reduced if possible,
but the subquery itself will never mark itself as a constant and never
be reducible.