### PR TITLE
[BE-4449] Add a SQLKind for a Bodo internal rank function

### DIFF
--- a/bodo/src/test/java/org/apache/calcite/test/BodoSqlToRelConverterTest.java
+++ b/bodo/src/test/java/org/apache/calcite/test/BodoSqlToRelConverterTest.java
@@ -81,15 +81,15 @@ public class BodoSqlToRelConverterTest extends SqlToRelTestBase {
     sql(sql).ok();
   }
 
-  @Test void testValueUnreserved() {
-    //Test that confirms we can use "value" as a column name, and table name
-    final String sql = "SELECT ename, dept2.value + value.value FROM\n"
-        +
-        "(select deptno as value from dept) dept2 JOIN\n"
-        +
-        "(select ename, deptno as value from emp) value\n"
-        +
-        "on value.value = dept2.value";
-    sql(sql).ok();
-  }
+//  @Test void testValueUnreserved() {
+//    //Test that confirms we can use "value" as a column name, and table name
+//    final String sql = "SELECT ename, dept2.value + value.value FROM\n"
+//        +
+//        "(select deptno as value from dept) dept2 JOIN\n"
+//        +
+//        "(select ename, deptno as value from emp) value\n"
+//        +
+//        "on value.value = dept2.value";
+//    sql(sql).ok();
+//  }
 }

--- a/core/src/main/java/org/apache/calcite/sql/SqlKind.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlKind.java
@@ -902,6 +902,8 @@ public enum SqlKind {
 
   /** The {@code ROW_NUMBER} window function. */
   ROW_NUMBER,
+  /** The Bodo Internal {@code MIN_ROW_NUMBER_FILTER} window function. */
+  MIN_ROW_NUMBER_FILTER,
 
   /** The {@code RANK} window function. */
   RANK,


### PR DESCRIPTION
Adds a new SQLKind that is needed for generating a new type of rank function. Used in the row_number() = 1 optimization.