### PR TITLE
Fixes create table's unconditional re-write behavior

### DIFF
--- a/babel/src/main/java/org/apache/calcite/sql/babel/SqlBabelCreateTable.java
+++ b/babel/src/main/java/org/apache/calcite/sql/babel/SqlBabelCreateTable.java
@@ -25,6 +25,8 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.sql.validate.SqlValidatorScope;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 import static org.apache.calcite.util.Static.RESOURCE;
 
 /**
@@ -88,7 +90,9 @@ public class SqlBabelCreateTable extends SqlCreateTable {
     if (ifNotExists) {
       writer.keyword("IF NOT EXISTS");
     }
-    name.unparse(writer, leftPrec, rightPrec);
+
+    this.getName().unparse(writer, leftPrec, rightPrec);
+    @Nullable SqlNodeList columnList = getcolumnList();
     if (columnList != null) {
       SqlWriter.Frame frame = writer.startList("(", ")");
       for (SqlNode c : columnList) {
@@ -97,6 +101,7 @@ public class SqlBabelCreateTable extends SqlCreateTable {
       }
       writer.endList(frame);
     }
+    SqlNode query = getQuery();
     if (query != null) {
       writer.keyword("AS");
       writer.newlineAndIndent();

--- a/bodo/src/main/java/org/apache/calcite/sql/bodo/SqlBodoCreateTable.java
+++ b/bodo/src/main/java/org/apache/calcite/sql/bodo/SqlBodoCreateTable.java
@@ -25,6 +25,10 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.sql.validate.SqlValidatorScope;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.List;
+
 import static org.apache.calcite.util.Static.RESOURCE;
 
 /**
@@ -67,7 +71,8 @@ public class SqlBodoCreateTable extends SqlCreateTable {
     if (ifNotExists) {
       writer.keyword("IF NOT EXISTS");
     }
-    name.unparse(writer, leftPrec, rightPrec);
+    this.getName().unparse(writer, leftPrec, rightPrec);
+    @Nullable SqlNodeList columnList = getcolumnList();
     if (columnList != null) {
       SqlWriter.Frame frame = writer.startList("(", ")");
       for (SqlNode c : columnList) {
@@ -76,10 +81,15 @@ public class SqlBodoCreateTable extends SqlCreateTable {
       }
       writer.endList(frame);
     }
+    SqlNode query = getQuery();
     if (query != null) {
       writer.keyword("AS");
       writer.newlineAndIndent();
       query.unparse(writer, 0, 0);
     }
+  }
+
+  @Override public List<SqlNode> getOperandList() {
+    return super.getOperandList();
   }
 }

--- a/bodo/src/main/java/org/apache/calcite/sql/bodo/SqlBodoCreateTable.java
+++ b/bodo/src/main/java/org/apache/calcite/sql/bodo/SqlBodoCreateTable.java
@@ -27,8 +27,6 @@ import org.apache.calcite.sql.validate.SqlValidatorScope;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-import java.util.List;
-
 import static org.apache.calcite.util.Static.RESOURCE;
 
 /**

--- a/bodo/src/main/java/org/apache/calcite/sql/bodo/SqlBodoCreateTable.java
+++ b/bodo/src/main/java/org/apache/calcite/sql/bodo/SqlBodoCreateTable.java
@@ -89,7 +89,4 @@ public class SqlBodoCreateTable extends SqlCreateTable {
     }
   }
 
-  @Override public List<SqlNode> getOperandList() {
-    return super.getOperandList();
-  }
 }

--- a/bodo/src/test/java/org/apache/calcite/test/BodoSqlToRelConverterTest.java
+++ b/bodo/src/test/java/org/apache/calcite/test/BodoSqlToRelConverterTest.java
@@ -68,6 +68,13 @@ public class BodoSqlToRelConverterTest extends SqlToRelTestBase {
   }
 
 
+  @Test void testCreateTableRewrite() {
+    // Tests create table with a query that will require unconditional rewriting
+    final String sql = "CREATE TABLE foo as select * from dept limit 10";
+    sql(sql).withExtendedTester().ok();
+  }
+
+
 
   @Test void testValuesUnreserved() {
     //Test that confirms we can use "values" as a column name, and table name

--- a/bodo/src/test/resources/org/apache/calcite/test/BodoSqlToRelConverterTest.xml
+++ b/bodo/src/test/resources/org/apache/calcite/test/BodoSqlToRelConverterTest.xml
@@ -36,6 +36,16 @@ LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[SALES]], IsReplace=[fal
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testCreateTableRewrite">
+    <Resource name="plan">
+      <![CDATA[
+LogicalTableCreate(TableName=[FOO], Target Schema=[[SALES]], IsReplace=[false])
+  LogicalSort(fetch=[10])
+    LogicalProject(DEPTNO=[$0], NAME=[$1])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testCreateTableSimple">
     <Resource name="plan">
       <![CDATA[

--- a/core/src/main/java/org/apache/calcite/sql/ddl/SqlCreateTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/ddl/SqlCreateTable.java
@@ -39,9 +39,12 @@ import java.util.Objects;
  * Parse tree for {@code CREATE TABLE} statement.
  */
 public class SqlCreateTable extends SqlCreate {
-  public final SqlIdentifier name;
-  public final @Nullable SqlNodeList columnList;
-  public final @Nullable SqlNode query;
+
+  // These values should only be changed by calls to setOperand,
+  // which should only be called during unconditional rewrite.
+  private SqlIdentifier name;
+  private @Nullable SqlNodeList columnList;
+  private @Nullable SqlNode query;
 
 
   /* set during validation, null before that point */
@@ -66,7 +69,24 @@ public class SqlCreateTable extends SqlCreate {
     return ImmutableNullableList.of(name, columnList, query);
   }
 
-
+  @SuppressWarnings("assignment.type.incompatible")
+  @Override public void setOperand(int i, @Nullable SqlNode operand) {
+    switch (i) {
+    case 0:
+      assert operand instanceof SqlIdentifier;
+      name = (SqlIdentifier) operand;
+      break;
+    case 1:
+      assert operand instanceof SqlNodeList;
+      columnList = (SqlNodeList) operand;
+      break;
+    case 2:
+      query = operand;
+      break;
+    default:
+      throw new AssertionError(i);
+    }
+  }
 
   @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
     writer.keyword("CREATE");
@@ -104,6 +124,17 @@ public class SqlCreateTable extends SqlCreate {
     this.outputTableSchemaPath = path;
   }
 
+  public @Nullable SqlIdentifier getName() {
+    return name;
+  }
+
+  public @Nullable SqlNodeList getcolumnList() {
+    return columnList;
+  }
+  public @Nullable SqlNode getQuery() {
+    return query;
+  }
+
   public @Nullable Schema getOutputTableSchema() {
     return outputTableSchema;
   }
@@ -112,9 +143,8 @@ public class SqlCreateTable extends SqlCreate {
     return outputTableSchemaPath;
   }
 
-  public @Nullable String getOutputTableName() {
+  public String getOutputTableName() {
     return outputTableName;
   }
-
 
 }

--- a/core/src/main/java/org/apache/calcite/sql/ddl/SqlCreateTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/ddl/SqlCreateTable.java
@@ -103,10 +103,12 @@ public class SqlCreateTable extends SqlCreate {
       }
       writer.endList(frame);
     }
-    if (query != null) {
+    //Required to appease the Calcite null checker
+    SqlNode queryNode = query;
+    if (queryNode != null) {
       writer.keyword("AS");
       writer.newlineAndIndent();
-      query.unparse(writer, 0, 0);
+      queryNode.unparse(writer, 0, 0);
     }
   }
 
@@ -124,7 +126,7 @@ public class SqlCreateTable extends SqlCreate {
     this.outputTableSchemaPath = path;
   }
 
-  public @Nullable SqlIdentifier getName() {
+  public SqlIdentifier getName() {
     return name;
   }
 
@@ -143,7 +145,7 @@ public class SqlCreateTable extends SqlCreate {
     return outputTableSchemaPath;
   }
 
-  public String getOutputTableName() {
+  public @Nullable String getOutputTableName() {
     return outputTableName;
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -2884,7 +2884,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
     // to confirm that the sql dialect we're validating for even supports CREATE_TABLE.
     // This will be done as followup: https://bodo.atlassian.net/browse/BE-4429
 
-    final SqlNode queryNode = createTable.query;
+    final SqlNode queryNode = createTable.getQuery();
 
     // NOTE: query can be null, in the case that we're just doing a table definition with no data.
     // For now, only supporting the case where we have a query
@@ -5440,7 +5440,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
     }
 
 
-    final SqlNode queryNode = createTable.query;
+    final SqlNode queryNode = createTable.getQuery();
     if (queryNode == null) {
       throw newValidationError(createTable, RESOURCE.createTableRequiresAsQuery());
     }
@@ -5461,7 +5461,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
     //Row type of the overall create statement should be the same as that of the underlying query
     assert queryNS.getRowType().equals(createTableNS.getRowType());
 
-    final SqlIdentifier tableNameNode = createTable.name;
+    final SqlIdentifier tableNameNode = createTable.getName();
     final List<String> names = tableNameNode.names;
 
     final SqlValidatorScope.ResolvedImpl resolved = new SqlValidatorScope.ResolvedImpl();

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -4408,7 +4408,7 @@ public class SqlToRelConverter {
 
     // NOTE: We currently require a SqlCreateTable to have a query in valiation,
     // so the call to requireNonNull is valid here
-    RelRoot relRoot = convertQueryRecursive(requireNonNull(call.query), false, null);
+    RelRoot relRoot = convertQueryRecursive(requireNonNull(call.getQuery()), false, null);
 
     return LogicalTableCreate.create(
         relRoot.rel,


### PR DESCRIPTION
Current create table implementation will fail if it uses a sub query which is modified during the "unconditional rewrites" portion of the validation. 

Associated bodo PR that tests if this fixes Q7: https://github.com/Bodo-inc/Bodo/pull/5007