### PR TITLE
[BE-3986] Keaton fix create table

### DIFF
--- a/bodo/src/test/java/org/apache/calcite/test/BodoSqlToRelConverterTest.java
+++ b/bodo/src/test/java/org/apache/calcite/test/BodoSqlToRelConverterTest.java
@@ -75,7 +75,19 @@ public class BodoSqlToRelConverterTest extends SqlToRelTestBase {
   }
 
 
-
+  @Test void testCreateTableWith() {
+    // Tests create table with a query that uses "with" syntax
+    final String sql = "CREATE TABLE foo as\n"
+        +
+        "with temporaryTable as (select * from dept limit 10),\n"
+        +
+        "temporaryTable2 as (select * from dept limit 10)\n"
+        +
+        "SELECT * from temporaryTable join temporaryTable2\n"
+        +
+        "on temporaryTable.deptno = temporaryTable2.deptno";
+    sql(sql).withExtendedTester().ok();
+  }
   @Test void testValuesUnreserved() {
     //Test that confirms we can use "values" as a column name, and table name
     final String sql = "SELECT ename, dept2.values + values.values FROM\n"

--- a/bodo/src/test/java/org/apache/calcite/test/BodoSqlToRelConverterTest.java
+++ b/bodo/src/test/java/org/apache/calcite/test/BodoSqlToRelConverterTest.java
@@ -113,18 +113,55 @@ public class BodoSqlToRelConverterTest extends SqlToRelTestBase {
   }
 
   @Test void testCreateTableOrderBy() {
-    //Test an error found while doing a test run on tpch Q2
-    final String sql = "CREATE TABLE keaton_testing AS (" +
-        "with part_two as (\n" +
-        "        select 'foo' as p_partkey from (VALUES (1, 2, 3))\n" +
-        "    )\n" +
-        "    select\n" +
-        "                       p_partkey\n" +
-        "                     from\n" +
-        "                       part_two\n" +
-        "                     order by\n" +
-        "                       p_partkey" +
+    // Tests an error specific to CREATE TABLE with "WITH" and "ORDER BY" clauses
+    // found while doing a test run on tpch Q2
+    final String sql = "CREATE TABLE keaton_testing AS ("
+        +
+        "with part_two as (\n"
+        +
+        "        select 'foo' as p_partkey from (VALUES (1, 2, 3))\n"
+        +
+        "    )\n"
+        +
+        "    select\n"
+        +
+        "                       p_partkey\n"
+        +
+        "                     from\n"
+        +
+        "                       part_two\n"
+        +
+        "                     order by\n"
+        +
+        "                       p_partkey"
+        +
         ")";
+    sql(sql).ok();
+  }
+
+  @Test void testOrderByNoCreateTable() {
+    // Tests an error specific to CREATE TABLE with "WITH" and "ORDER BY" clauses
+    // Adding this test in the case that we come back to this:
+    // https://bodo.atlassian.net/browse/BE-4483,
+    // so that we don't accidentally break the existing create-table path
+    final String sql =
+        "with part_two as (\n"
+        +
+        "        select 'foo' as p_partkey from (VALUES (1, 2, 3))\n"
+        +
+        "    )\n"
+        +
+        "    select\n"
+        +
+        "                       p_partkey\n"
+        +
+        "                     from\n"
+        +
+        "                       part_two\n"
+        +
+        "                     order by\n"
+        +
+        "                       p_partkey";
     sql(sql).ok();
   }
 

--- a/bodo/src/test/java/org/apache/calcite/test/BodoSqlToRelConverterTest.java
+++ b/bodo/src/test/java/org/apache/calcite/test/BodoSqlToRelConverterTest.java
@@ -111,4 +111,21 @@ public class BodoSqlToRelConverterTest extends SqlToRelTestBase {
         "on value.value = dept2.value";
     sql(sql).ok();
   }
+
+  @Test void testCreateTableOrderBy() {
+    //Test an error found while doing a test run on tpch Q2
+    final String sql = "CREATE TABLE keaton_testing AS (" +
+        "with part_two as (\n" +
+        "        select 'foo' as p_partkey from (VALUES (1, 2, 3))\n" +
+        "    )\n" +
+        "    select\n" +
+        "                       p_partkey\n" +
+        "                     from\n" +
+        "                       part_two\n" +
+        "                     order by\n" +
+        "                       p_partkey" +
+        ")";
+    sql(sql).ok();
+  }
+
 }

--- a/bodo/src/test/java/org/apache/calcite/test/BodoSqlToRelConverterTest.java
+++ b/bodo/src/test/java/org/apache/calcite/test/BodoSqlToRelConverterTest.java
@@ -113,9 +113,12 @@ public class BodoSqlToRelConverterTest extends SqlToRelTestBase {
   }
 
   @Test void testCreateTableOrderBy() {
-    // Tests an error specific to CREATE TABLE with "WITH" and "ORDER BY" clauses
-    // found while doing a test run on tpch Q2
-    final String sql = "CREATE TABLE keaton_testing AS ("
+    // Tests an error specific to CREATE TABLE with "WITH" and "ORDER BY" clauses during
+    // SqlToRelConversion. The converter was previously optimizing out the sort node,
+    // but its parent process expected the conversion collation to exist, which lead
+    // to an assertion error.
+
+    final String sql = "CREATE TABLE testing_output AS ("
         +
         "with part_two as (\n"
         +
@@ -140,10 +143,11 @@ public class BodoSqlToRelConverterTest extends SqlToRelTestBase {
   }
 
   @Test void testOrderByNoCreateTable() {
-    // Tests an error specific to CREATE TABLE with "WITH" and "ORDER BY" clauses
-    // Adding this test in the case that we come back to this:
-    // https://bodo.atlassian.net/browse/BE-4483,
-    // so that we don't accidentally break the existing create-table path
+    // Tests that the default path for a query with "WITH" and "ORDER BY" clauses still works.
+    // This test should not be necessary at this time, but it may be useful in
+    // the case that we attempt to resolve the "WITH"/"ORDER BY" clause issue in a more performant
+    // way:
+    // https://bodo.atlassian.net/browse/BE-4483
     final String sql =
         "with part_two as (\n"
         +

--- a/bodo/src/test/resources/org/apache/calcite/test/BodoSqlToRelConverterTest.xml
+++ b/bodo/src/test/resources/org/apache/calcite/test/BodoSqlToRelConverterTest.xml
@@ -26,6 +26,11 @@ LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[CUSTOMER]], IsReplace=[
       LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
 ]]>
     </Resource>
+    <Resource name="sql">
+      <![CDATA[CREATE OR REPLACE TABLE CUSTOMER.out_test AS
+select dept.deptno, emp.empno
+ from emp join dept on emp.deptno = dept.deptno]]>
+    </Resource>
   </TestCase>
   <TestCase name="testCreateTableIfNotExists">
     <Resource name="plan">
@@ -34,6 +39,9 @@ LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[SALES]], IsReplace=[fal
   LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
+    </Resource>
+    <Resource name="sql">
+      <![CDATA[CREATE TABLE IF NOT EXISTS out_test AS select * from emp]]>
     </Resource>
   </TestCase>
   <TestCase name="testCreateTableRewrite">
@@ -45,6 +53,9 @@ LogicalTableCreate(TableName=[FOO], Target Schema=[[SALES]], IsReplace=[false])
       LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
 ]]>
     </Resource>
+    <Resource name="sql">
+      <![CDATA[CREATE TABLE foo as select * from dept limit 10]]>
+    </Resource>
   </TestCase>
   <TestCase name="testCreateTableSimple">
     <Resource name="plan">
@@ -53,6 +64,28 @@ LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[SALES]], IsReplace=[fal
   LogicalProject(EXPR$0=[1], EXPR$1=[2], EXPR$2=[3])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCreateTableWith">
+    <Resource name="plan">
+      <![CDATA[
+LogicalTableCreate(TableName=[FOO], Target Schema=[[SALES]], IsReplace=[false])
+  LogicalProject(DEPTNO=[$0], NAME=[$1], DEPTNO0=[$2], NAME0=[$3])
+    LogicalJoin(condition=[=($0, $2)], joinType=[inner])
+      LogicalSort(fetch=[10])
+        LogicalProject(DEPTNO=[$0], NAME=[$1])
+          LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+      LogicalSort(fetch=[10])
+        LogicalProject(DEPTNO=[$0], NAME=[$1])
+          LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+    </Resource>
+    <Resource name="sql">
+      <![CDATA[CREATE TABLE foo as
+with temporaryTable as (select * from dept limit 10),
+temporaryTable2 as (select * from dept limit 10)
+SELECT * from temporaryTable join temporaryTable2
+on temporaryTable.deptno = temporaryTable2.deptno]]>
     </Resource>
   </TestCase>
   <TestCase name="testValueUnreserved">
@@ -66,6 +99,12 @@ LogicalProject(ENAME=[$1], EXPR$1=[+($0, $2)])
       LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
     </Resource>
+    <Resource name="sql">
+      <![CDATA[SELECT ename, dept2.value + value.value FROM
+(select deptno as value from dept) dept2 JOIN
+(select ename, deptno as value from emp) value
+on value.value = dept2.value]]>
+    </Resource>
   </TestCase>
   <TestCase name="testValuesUnreserved">
     <Resource name="plan">
@@ -77,6 +116,12 @@ LogicalProject(ENAME=[$1], EXPR$1=[+($0, $2)])
     LogicalProject(ENAME=[$1], VALUES=[$7])
       LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
+    </Resource>
+    <Resource name="sql">
+      <![CDATA[SELECT ename, dept2.values + values.values FROM
+(select deptno as values from dept) dept2 JOIN
+(select ename, deptno as values from emp) values
+on values.values = dept2.values]]>
     </Resource>
   </TestCase>
   <TestCase name="testWithBodoParser">

--- a/bodo/src/test/resources/org/apache/calcite/test/BodoSqlToRelConverterTest.xml
+++ b/bodo/src/test/resources/org/apache/calcite/test/BodoSqlToRelConverterTest.xml
@@ -44,6 +44,16 @@ LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[SALES]], IsReplace=[fal
       <![CDATA[CREATE TABLE IF NOT EXISTS out_test AS select * from emp]]>
     </Resource>
   </TestCase>
+  <TestCase name="testCreateTableOrderBy">
+    <Resource name="plan">
+      <![CDATA[
+LogicalTableCreate(TableName=[KEATON_TESTING], Target Schema=[[SALES]], IsReplace=[false])
+  LogicalSort(sort0=[$0], dir0=[ASC])
+    LogicalProject(P_PARTKEY=[$0])
+      LogicalValues(tuples=[[{ 'foo' }]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testCreateTableRewrite">
     <Resource name="plan">
       <![CDATA[
@@ -86,6 +96,15 @@ with temporaryTable as (select * from dept limit 10),
 temporaryTable2 as (select * from dept limit 10)
 SELECT * from temporaryTable join temporaryTable2
 on temporaryTable.deptno = temporaryTable2.deptno]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testOrderByNoCreateTable">
+    <Resource name="plan">
+      <![CDATA[
+LogicalSort(sort0=[$0], dir0=[ASC])
+  LogicalProject(P_PARTKEY=[$0])
+    LogicalValues(tuples=[[{ 'foo' }]])
+]]>
     </Resource>
   </TestCase>
   <TestCase name="testValueUnreserved">

--- a/bodo/src/test/resources/org/apache/calcite/test/BodoSqlToRelConverterTest.xml
+++ b/bodo/src/test/resources/org/apache/calcite/test/BodoSqlToRelConverterTest.xml
@@ -47,7 +47,7 @@ LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[SALES]], IsReplace=[fal
   <TestCase name="testCreateTableOrderBy">
     <Resource name="plan">
       <![CDATA[
-LogicalTableCreate(TableName=[KEATON_TESTING], Target Schema=[[SALES]], IsReplace=[false])
+LogicalTableCreate(TableName=[TESTING_OUTPUT], Target Schema=[[SALES]], IsReplace=[false])
   LogicalSort(sort0=[$0], dir0=[ASC])
     LogicalProject(P_PARTKEY=[$0])
       LogicalValues(tuples=[[{ 'foo' }]])

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidator.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidator.java
@@ -656,6 +656,15 @@ public interface SqlValidator {
   SqlValidatorScope getOrderScope(SqlSelect select);
 
   /**
+   * Returns the scope that should be used when converting the create table
+   * sub query/table reference.
+   *
+   * @param createTable CREATE TABLE statement
+   * @return scope used for the sub query/table reference.
+   */
+  SqlValidatorScope getCreateTableScope(SqlCreateTable createTable);
+
+  /**
    * Returns a scope match recognize clause.
    *
    * @param node Match recognize

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidator.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidator.java
@@ -656,7 +656,8 @@ public interface SqlValidator {
   SqlValidatorScope getOrderScope(SqlSelect select);
 
   /**
-   * Returns the scope that should be used when converting the create table
+   * Returns the scope of the Create Table statement, IE,
+   * the scope that should be used when converting the create table
    * sub query/table reference.
    *
    * @param createTable CREATE TABLE statement

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -5489,7 +5489,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
     // Note, this can either a row expression or a query expression with an optional ORDER BY
     // We're not currently handling the row expression case.
     // This may or may not be within the scope of what we want
-    // to support by relese: (https://bodo.atlassian.net/browse/BE-4478)
+    // to support by release: (https://bodo.atlassian.net/browse/BE-4478)
 
     SqlValidatorScope createTableScope = this.getCreateTableScope(createTable);
     // we have to validate in the overall scope of the create table node in order to be

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -5493,7 +5493,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
     // In order to be sufficiently general to the input of Create table,
     // We have to validate this expression in the overall scope of the create table node,
     // Since the associated query node
-    // doesn't necessarily have to be a select (notably, validaSelect doesn't work if the query has
+    // doesn't necessarily have to be a select (notably, validateSelect doesn't work if the query has
     // any 'with' clauses)
     // Note that we also can't use validateScopedExpression, as this can rewrite the sqlNode
     // via a call to performUnconditionalRewrites, which should have already been done by the time

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -5486,20 +5486,22 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
       throw newValidationError(createTable, RESOURCE.createTableRequiresAsQuery());
     }
 
-    //Note, this can either a row expression or a query expression with an optional ORDER BY
-    //We're not currently handling the row expression case.
+    // Note, this can either a row expression or a query expression with an optional ORDER BY
+    // We're not currently handling the row expression case.
+    // This may or may not be within the scope of what we want
+    // to support by relese: (https://bodo.atlassian.net/browse/BE-4478)
 
     SqlValidatorScope createTableScope = this.getCreateTableScope(createTable);
-    // In order to be sufficiently general to the input of Create table,
-    // We have to validate this expression in the overall scope of the create table node,
-    // Since the associated query node
-    // doesn't necessarily have to be a select (notably, validateSelect doesn't work if the query has
-    // any 'with' clauses)
-    // Note that we also can't use validateScopedExpression, as this can rewrite the sqlNode
-    // via a call to performUnconditionalRewrites, which should have already been done by the time
-    // that we reach this points, and calling performUnconditionalRewrites twice is likely invalid.
+    // we have to validate in the overall scope of the create table node in order to be
+    // sufficiently general to the input of "create table as", since the associated query node
+    // (in relation to the Create Table node) may not be a selectScope or any one type of scope
+
+    // Note that we don't use validateScopedExpression, since validateScopedExpression only does
+    // some additional rewriting before calling node.validate(), and the rewriting should already
+    // have occurred by the time we reach this point.
     queryNode.validate(this, createTableScope);
-    // (Note: for create table LIKE (WIP) if queryNode is identifier, we may need additional work to
+    // (Note: for create table LIKE (https://bodo.atlassian.net/browse/BE-3989) if
+    // queryNode is identifier, we may need additional work to
     // properly validate)
 
 

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -2911,7 +2911,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
     // Store the scope of the create table node itself.
     // This will be used later during validation to resolve table aliases and/or
     // the associated sub query.
-    // Since the create table node is always the topmost node, I believe that the usingScope
+    // Since the create table node is always the topmost node, the usingScope
     // should always be null, but better to be overly defensive.
     scopes.put(createTable, (usingScope != null) ? usingScope : parentScope);
   }

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -1169,6 +1169,10 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
     return scopes.get(select);
   }
 
+  @Override public SqlValidatorScope getCreateTableScope(SqlCreateTable createTable) {
+    return requireNonNull(scopes.get(createTable));
+  }
+
   @Override public SqlValidatorScope getOrderScope(SqlSelect select) {
     return getScope(select, Clause.ORDER);
   }
@@ -2904,6 +2908,12 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
     } else {
       throw newValidationError(createTable, RESOURCE.createTableRequiresAsQuery());
     }
+    // Store the scope of the create table node itself.
+    // This will be used later during validation to resolve table aliases and/or
+    // the associated sub query.
+    // Since the create table node is always the topmost node, I believe that the usingScope
+    // should always be null, but better to be overly defensive.
+    scopes.put(createTable, (usingScope != null) ? usingScope : parentScope);
   }
 
   /**
@@ -5476,29 +5486,30 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
       throw newValidationError(createTable, RESOURCE.createTableRequiresAsQuery());
     }
 
-    final SqlValidatorScope queryScope = requireNonNull(scopes.get(queryNode));
-
     //Note, this can either a row expression or a query expression with an optional ORDER BY
-    if (queryNode instanceof SqlSelect) {
-      final SqlSelect sqlSelect = (SqlSelect) queryNode;
-      validateSelect(sqlSelect, unknownType);
-    } else {
-      validateQuery(queryNode, queryScope, unknownType);
-    }
+    //We're not currently handling the row expression case.
 
-    final SqlValidatorNamespace queryNS = getNamespaceOrThrow(queryNode);
-    final DdlNamespace createTableNS = (DdlNamespace) getNamespaceOrThrow(createTable);
+    SqlValidatorScope createTableScope = this.getCreateTableScope(createTable);
+    // In order to be sufficiently general to the input of Create table,
+    // We have to validate this expression in the overall scope of the create table node,
+    // Since the associated query node
+    // doesn't necessarily have to be a select (notably, validaSelect doesn't work if the query has
+    // any 'with' clauses)
+    // Note that we also can't use validateScopedExpression, as this can rewrite the sqlNode
+    // via a call to performUnconditionalRewrites, which should have already been done by the time
+    // that we reach this points, and calling performUnconditionalRewrites twice is likely invalid.
+    queryNode.validate(this, createTableScope);
+    // (Note: for create table LIKE (WIP) if queryNode is identifier, we may need additional work to
+    // properly validate)
 
-    //Row type of the overall create statement should be the same as that of the underlying query
-    assert queryNS.getRowType().equals(createTableNS.getRowType());
 
     final SqlIdentifier tableNameNode = createTable.getName();
     final List<String> names = tableNameNode.names;
 
+    //Create an empty resolve to accumulate the results
     final SqlValidatorScope.ResolvedImpl resolved = new SqlValidatorScope.ResolvedImpl();
-    CatalogScope temp = (CatalogScope) ((SelectScope) queryScope).parent;
 
-    temp.resolveSchema(
+    createTableScope.resolveSchema(
         Util.skipLast(names), //Skip the last name element (the table name)
         this.catalogReader.nameMatcher(),
         SqlValidatorScope.Path.EMPTY,


### PR DESCRIPTION
Originally, create table used the scope of the sub query in order to resolve any table aliases. However, this doesn't work in the case that the sub query is not a explicit select.

Therefore, instead of relying on the sub query to supply the needed scope, I've changed the code to simply store the correct scope during registration, and then use it during validation.