### PR TITLE
[BE-4249] Allows having in non-aggregate

### DIFF
--- a/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
+++ b/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
@@ -395,6 +395,9 @@ public interface CalciteResource {
   @BaseMessage("HAVING clause must be a condition")
   ExInst<SqlValidatorException> havingMustBeBoolean();
 
+  @BaseMessage("A non-aggregate SELECT statement cannot have both a HAVING and WHERE clause")
+  ExInst<SqlValidatorException> havingAndWhereNotAllowedInNonAggregate();
+
   @BaseMessage("QUALIFY clause must be a boolean condition")
   ExInst<SqlValidatorException> qualifyMustBeBoolean();
 

--- a/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
+++ b/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
@@ -395,8 +395,6 @@ public interface CalciteResource {
   @BaseMessage("HAVING clause must be a condition")
   ExInst<SqlValidatorException> havingMustBeBoolean();
 
-  @BaseMessage("A non-aggregate SELECT statement cannot have both a HAVING and WHERE clause")
-  ExInst<SqlValidatorException> havingAndWhereNotAllowedInNonAggregate();
 
   @BaseMessage("QUALIFY clause must be a boolean condition")
   ExInst<SqlValidatorException> qualifyMustBeBoolean();

--- a/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
+++ b/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
@@ -394,8 +394,7 @@ public interface CalciteResource {
 
   @BaseMessage("HAVING clause must be a condition")
   ExInst<SqlValidatorException> havingMustBeBoolean();
-
-
+  
   @BaseMessage("QUALIFY clause must be a boolean condition")
   ExInst<SqlValidatorException> qualifyMustBeBoolean();
 

--- a/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
+++ b/core/src/main/java/org/apache/calcite/runtime/CalciteResource.java
@@ -394,7 +394,7 @@ public interface CalciteResource {
 
   @BaseMessage("HAVING clause must be a condition")
   ExInst<SqlValidatorException> havingMustBeBoolean();
-  
+
   @BaseMessage("QUALIFY clause must be a boolean condition")
   ExInst<SqlValidatorException> qualifyMustBeBoolean();
 

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -690,7 +690,7 @@ public class SqlToRelConverter {
     // we have a non-aggregate select.
     SqlNode whereClause = select.getWhere();
     SqlNode havingClause = select.getHaving();
-    if (havingClause != null && !validator.isAggregate(select)) {
+    if (havingClause != null && !validator().isAggregate(select)) {
       if (whereClause != null) {
         //If we have a where clause, AND the two together (this is the expected behavior in SF)
         //Note that we've already validated the WHERE clause. Since we've validated both of the

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -685,6 +685,25 @@ public class SqlToRelConverter {
     return new Blackboard(scope, nameToNodeMap, top);
   }
 
+  private void handleNonAggregateHavingReWrite(SqlSelect select) {
+    // Re-writes the having as a part of the WHERE clause now, in the case that
+    // we have a non-aggregate select.
+    SqlNode whereClause = select.getWhere();
+    SqlNode havingClause = select.getHaving();
+    if (havingClause != null && !validator.isAggregate(select)) {
+      if (whereClause != null) {
+        //If we have a where clause, AND the two together (this is the expected behavior in SF)
+        //Note that we've already validated the WHERE clause. Since we've validated both of the
+        //individual clauses, we don't need to do any additional
+        //validation of the AND of the two expressions.
+        havingClause = SqlStdOperatorTable.AND.createCall(
+            SqlNodeList.of(whereClause, havingClause));
+      }
+      select.setHaving(null);
+      select.setWhere(havingClause);
+    }
+  }
+
   /**
    * Implementation of {@link #convertSelect(SqlSelect, boolean)};
    * derived class may override.
@@ -692,6 +711,13 @@ public class SqlToRelConverter {
   protected void convertSelectImpl(
       final Blackboard bb,
       SqlSelect select) {
+
+    // We handle the rewrite here, since we've already verified the having and/or thrown
+    // an error in the case that it's invalid, and we no longer need to know what expressions
+    // originated from what clauses.
+    // Doing this rewrite prior to anything else simplifies the rest of the SqlToRel conversion
+    handleNonAggregateHavingReWrite(select);
+
     convertFrom(
         bb,
         select.getFrom());

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -695,6 +695,12 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
     fixture.withSql(sql).ok();
   }
 
+  @Test void testHavingNonAggregate() {
+    // tests that we can have a having clause in the case that we have no aggregates in the select
+    final String sql = "select empno from emp having empno > 10";
+    sql(sql).ok();
+  }
+
   @Test void testQualifyWithAlias() {
     // test qualify on a simple clause, that contains an alias
     final String sql = "select empno, ROW_NUMBER() over (PARTITION BY deptno ORDER BY sal)\n"

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -701,6 +701,14 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
     sql(sql).ok();
   }
 
+
+  @Test void testHavingAndWhereNonAggregate() {
+    // tests that we can have a having clause and a where clause, that the two
+    // are properly AND'd together
+    final String sql = "select empno from emp WHERE empno < 20 having empno > 10";
+    sql(sql).ok();
+  }
+
   @Test void testQualifyWithAlias() {
     // test qualify on a simple clause, that contains an alias
     final String sql = "select empno, ROW_NUMBER() over (PARTITION BY deptno ORDER BY sal)\n"
@@ -2166,6 +2174,15 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
         + "join dept as d using (deptno)\n"
         + "where e.sal in (\n"
         + "  select e2.sal from emp as e2 where e2.deptno > e.deptno)";
+    sql(sql).withExpand(false).ok();
+  }
+
+  @Test void testNonAggregateHavingInCorrelated() {
+    //Tests that non-aggregate Having is identical to WHERE in this case
+    final String sql = "select empno from emp as e\n"
+        + "join dept as d using (deptno)\n"
+        + "having e.sal in (\n"
+        + "  select e2.sal from emp as e2 having e2.deptno > e.deptno)";
     sql(sql).withExpand(false).ok();
   }
 

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -5951,10 +5951,7 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
 
 
   @Test void testNonAggregateHavingReference() {
-    // You can refer to a table ('e1') in the parent scope of a query in
-    // the from clause.
-    //
-    // Note: Oracle10g does not allow this query.
+    // see testWhereReference
     sql("select * from emp as e1 having exists (\n"
         + "  select * from emp as e2,\n"
         + "    (select * from dept having dept.deptno = e1.deptno))").ok();
@@ -8588,10 +8585,10 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
 //        .fails("Expression 'DEPTNO' is not being grouped")
 //        .withConformance(SqlConformanceEnum.LENIENT)
 //        .fails("Expression 'DEPTNO' is not being grouped");
-//    sql("SELECT DISTINCT * from emp").ok();
+
+    sql("SELECT DISTINCT * from emp").ok();
     sql("SELECT DISTINCT ^*^ from emp GROUP BY deptno")
         .fails("Expression 'EMP\\.EMPNO' is not being grouped");
-
     // similar validation for SELECT DISTINCT and GROUP BY
     sql("SELECT deptno FROM emp GROUP BY deptno ORDER BY deptno, ^empno^")
         .fails("Expression 'EMPNO' is not being grouped");

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -5949,6 +5949,17 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         + "    (select * from dept where dept.deptno = e1.deptno))").ok();
   }
 
+
+  @Test void testNonAggregateHavingReference() {
+    // You can refer to a table ('e1') in the parent scope of a query in
+    // the from clause.
+    //
+    // Note: Oracle10g does not allow this query.
+    sql("select * from emp as e1 having exists (\n"
+        + "  select * from emp as e2,\n"
+        + "    (select * from dept having dept.deptno = e1.deptno))").ok();
+  }
+
   @Test void testUnionNameResolution() {
     sql("select * from emp as e1 where exists (\n"
         + "  select * from emp as e2,\n"
@@ -6427,6 +6438,24 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     sql("SELECT deptno FROM emp GROUP BY deptno HAVING ^sal^ > 10")
         .fails("Expression 'SAL' is not being grouped");
   }
+
+  @Test void testNonAggregateHaving() {
+    sql("select * from emp having ^sal^")
+        .fails("HAVING clause must be a condition");
+  }
+
+  @Test void testNonAggregateHavingAndWhere() {
+    sql("select * from emp WHERE ^sal^ having sal > 10")
+        .fails("WHERE clause must be a condition");
+
+    sql("select * from emp WHERE sal > 10 having ^sal^")
+        .fails("HAVING clause must be a condition");
+
+    sql("select * from emp WHERE sal > 10 having sal < 20")
+        .ok();
+  }
+
+
 
   @Test void testHavingBetween() {
     // FRG-115: having clause with between not working
@@ -8548,15 +8577,18 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     sql("SELECT deptno FROM emp GROUP BY deptno HAVING deptno > 55").ok();
     sql("SELECT DISTINCT deptno, 33 FROM emp\n"
         + "GROUP BY deptno HAVING deptno > 55").ok();
-    sql("SELECT DISTINCT deptno, 33 FROM emp HAVING ^deptno^ > 55")
-        .fails("Expression 'DEPTNO' is not being grouped")
-        .withConformance(SqlConformanceEnum.LENIENT)
-        .fails("Expression 'DEPTNO' is not being grouped");
-    sql("SELECT DISTINCT 33 FROM emp HAVING ^deptno^ > 55")
-        .fails("Expression 'DEPTNO' is not being grouped")
-        .withConformance(SqlConformanceEnum.LENIENT)
-        .fails("Expression 'DEPTNO' is not being grouped");
-    sql("SELECT DISTINCT * from emp").ok();
+
+    //Bodo change: since HAVING is now equivalent to WHERE in non-aggregate selects,
+    //these statements are now valid.
+//    sql("SELECT DISTINCT deptno, 33 FROM emp HAVING ^deptno^ > 55")
+//        .fails("Expression 'DEPTNO' is not being grouped")
+//        .withConformance(SqlConformanceEnum.LENIENT)
+//        .fails("Expression 'DEPTNO' is not being grouped");
+//    sql("SELECT DISTINCT 33 FROM emp HAVING ^deptno^ > 55")
+//        .fails("Expression 'DEPTNO' is not being grouped")
+//        .withConformance(SqlConformanceEnum.LENIENT)
+//        .fails("Expression 'DEPTNO' is not being grouped");
+//    sql("SELECT DISTINCT * from emp").ok();
     sql("SELECT DISTINCT ^*^ from emp GROUP BY deptno")
         .fails("Expression 'EMP\\.EMPNO' is not being grouped");
 

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -2720,6 +2720,15 @@ LogicalProject(EXPR$0=[$0])
       <![CDATA[select sum(sal + sal) from emp having sum(sal) > 10]]>
     </Resource>
   </TestCase>
+  <TestCase name="testHavingAndWhereNonAggregate">
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(EMPNO=[$0])
+  LogicalFilter(condition=[AND(<($0, 20), >($0, 10))])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testHavingAggrFunctionIn">
     <Resource name="sql">
       <![CDATA[select deptno
@@ -2762,6 +2771,15 @@ LogicalProject(SAL=[$0])
           LogicalAggregate(group=[{0}], agg#0=[SUM($0)])
             LogicalProject(DEPTNO=[$0])
               LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testHavingNonAggregate">
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(EMPNO=[$0])
+  LogicalFilter(condition=[>($0, 10)])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
     </Resource>
   </TestCase>
@@ -6027,6 +6045,21 @@ from sales.dept_nested dn]]>
       <![CDATA[
 LogicalProject(EXPR$0=[$2.OTHERS.A])
   LogicalTableScan(table=[[CATALOG, SALES, DEPT_NESTED]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testNonAggregateHavingInCorrelated">
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(EMPNO=[$0])
+  LogicalFilter(condition=[IN($5, {
+LogicalProject(SAL=[$5])
+  LogicalFilter(condition=[>($7, $cor0.DEPTNO)])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+})], variablesSet=[[$cor0]])
+    LogicalJoin(condition=[=($7, $9)], joinType=[inner])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
 ]]>
     </Resource>
   </TestCase>

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -2720,15 +2720,6 @@ LogicalProject(EXPR$0=[$0])
       <![CDATA[select sum(sal + sal) from emp having sum(sal) > 10]]>
     </Resource>
   </TestCase>
-  <TestCase name="testHavingAndWhereNonAggregate">
-    <Resource name="plan">
-      <![CDATA[
-LogicalProject(EMPNO=[$0])
-  LogicalFilter(condition=[AND(<($0, 20), >($0, 10))])
-    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-]]>
-    </Resource>
-  </TestCase>
   <TestCase name="testHavingAggrFunctionIn">
     <Resource name="sql">
       <![CDATA[select deptno
@@ -2745,6 +2736,18 @@ LogicalProject(DEPTNO=[$0])
       LogicalProject(DEPTNO=[$7], $f1=[CASE(SEARCH($7, Sarg[1, 2]), 0, 1)], $f2=[CASE(SEARCH($7, Sarg[3, 4]), 0, 1)])
         LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testHavingAndWhereNonAggregate">
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(EMPNO=[$0])
+  LogicalFilter(condition=[AND(<($0, 20), >($0, 10))])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="sql">
+      <![CDATA[select empno from emp WHERE empno < 20 having empno > 10]]>
     </Resource>
   </TestCase>
   <TestCase name="testHavingInSubQueryWithAggrFunction">
@@ -2781,6 +2784,9 @@ LogicalProject(EMPNO=[$0])
   LogicalFilter(condition=[>($0, 10)])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
+    </Resource>
+    <Resource name="sql">
+      <![CDATA[select empno from emp having empno > 10]]>
     </Resource>
   </TestCase>
   <TestCase name="testHopTable">
@@ -6061,6 +6067,12 @@ LogicalProject(SAL=[$5])
       LogicalTableScan(table=[[CATALOG, SALES, EMP]])
       LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
 ]]>
+    </Resource>
+    <Resource name="sql">
+      <![CDATA[select empno from emp as e
+join dept as d using (deptno)
+having e.sal in (
+  select e2.sal from emp as e2 having e2.deptno > e.deptno)]]>
     </Resource>
   </TestCase>
   <TestCase name="testNotCaseInMoreClause">


### PR DESCRIPTION
Associated Bodo PR: https://github.com/Bodo-inc/Bodo/pull/5029

The behavior of HAVING in a non-aggregate select query is identical to a WHERE clause in Snowflake. In Calcite, HAVING must be within an aggregate select query. This PR updates that behavior.

Implementation thoughts:
Initially, I just wanted to rewrite the query in unconditionalRewrites. However, when later doing validation, it makes it much more difficult to distinguish what expressions originated from the WHERE or HAVING, which makes it difficult to throw errors. I decided to do the rewrite after validating the two clauses, in order to properly throw reasonable errors. 

For full correctness, this behavior should likely be controlled sort of a configurable (https://bodo.atlassian.net/browse/BE-4477), but I'm going to leave this to a followup issue.

Alice and Johnathan, tagging both of you. This isn't high priority, whichever of you can get to it first is fine.

Edit: Alice has some other PR's in the backlog, taking her off this one.