### PR TITLE
[BE-4571]Support DATE function with optional format string

### DIFF
--- a/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
+++ b/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
@@ -165,7 +165,7 @@ class BabelParserTest extends SqlParserTest {
    * parser because it is a reserved keyword.
    * (Curiously, TIMESTAMP and TIME are not functions.) */
   @Test void testDateFunction() {
-    final String expected = "SELECT `DATE`(`X`)\n"
+    final String expected = "SELECT DATE(`X`)\n"
         + "FROM `T`";
     sql("select date(x) from t").ok(expected);
   }

--- a/babel/src/test/resources/sql/big-query.iq
+++ b/babel/src/test/resources/sql/big-query.iq
@@ -131,7 +131,7 @@ D
 
 select date(cast(null as varchar(10))) as d;
 D
-null
+1970-01-01
 !ok
 
 # End big-query.iq

--- a/bodo/src/test/java/org/apache/calcite/test/BodoParserTest.java
+++ b/bodo/src/test/java/org/apache/calcite/test/BodoParserTest.java
@@ -99,7 +99,7 @@ public class BodoParserTest extends SqlParserTest {
    * parser because it is a reserved keyword.
    * (Curiously, TIMESTAMP and TIME are not functions.) */
   @Test void testDateFunction() {
-    final String expected = "SELECT `DATE`(`X`)\n"
+    final String expected = "SELECT DATE(`X`)\n"
         + "FROM `T`";
     sql("select date(x) from t").ok(expected);
   }

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -4816,9 +4816,24 @@ SqlLiteral DateTimeLiteral() :
         return SqlParserUtil.parseTimestampLiteral(p, s.end(this));
     }
 |
-    <DATE> { s = span(); } <QUOTED_STRING> {
-        return SqlParserUtil.parseDateLiteral(token.image, s.end(this));
-    }
+    <DATE> { s = span(); }
+    (
+        <QUOTED_STRING> {
+            return SqlParserUtil.parseDateLiteral(token.image, s.end(this));
+        }
+    |
+        <LPAREN>
+        <QUOTED_STRING> {
+
+        }
+    [
+        <COMMA>
+        <QUOTED_STRING> {
+
+        }
+    ]
+        <LPAREN>
+    )
 |
     <TIME> { s = span(); } <QUOTED_STRING> {
         return SqlParserUtil.parseTimeLiteral(token.image, s.end(this));

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -6180,7 +6180,7 @@ SqlNode BuiltinFunctionCall() :
         <DATE> { s = span(); }
         <LPAREN>
         e = Expression(ExprContext.ACCEPT_SUB_QUERY) {
-            args.add(e);
+            args = startList(e);
         }
         [
         <COMMA>

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -4816,24 +4816,9 @@ SqlLiteral DateTimeLiteral() :
         return SqlParserUtil.parseTimestampLiteral(p, s.end(this));
     }
 |
-    <DATE> { s = span(); }
-    (
-        <QUOTED_STRING> {
-            return SqlParserUtil.parseDateLiteral(token.image, s.end(this));
-        }
-    |
-        <LPAREN>
-        <QUOTED_STRING> {
-
-        }
-    [
-        <COMMA>
-        <QUOTED_STRING> {
-
-        }
-    ]
-        <LPAREN>
-    )
+    <DATE> { s = span(); } <QUOTED_STRING> {
+        return SqlParserUtil.parseDateLiteral(token.image, s.end(this));
+    }
 |
     <TIME> { s = span(); } <QUOTED_STRING> {
         return SqlParserUtil.parseTimeLiteral(token.image, s.end(this));
@@ -6190,6 +6175,21 @@ SqlNode BuiltinFunctionCall() :
         e = Expression(ExprContext.ACCEPT_SUB_QUERY) { args.add(e); }
         <RPAREN> {
             return SqlStdOperatorTable.EXTRACT.createCall(s.end(this), args);
+        }
+    |
+        <DATE> { s = span(); }
+        <LPAREN>
+        e = Expression(ExprContext.ACCEPT_SUB_QUERY) {
+            args.add(e);
+        }
+        [
+        <COMMA>
+        e = Expression(ExprContext.ACCEPT_SUB_QUERY) {
+            args.add(e);
+        }
+        ]
+        <RPAREN> {
+            return SqlStdOperatorTable.DATE.createCall(s.end(this), args);
         }
     |
         <POSITION> { s = span(); }

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
@@ -2027,6 +2027,34 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
   public static final SqlFunction CAST = new SqlCastFunction();
 
   /**
+   * The Snowflake <code>DATE</code> function.
+   * The SQL syntaxs are
+   *
+   * DATE(string_expr [, format])
+   * DATE(timestamp_expr)
+   * DATE('integer>')
+   * DATE(variant_expr)
+   *  For conversion to date, snowflake allows a string, datetime, or integer.
+   *            If the first argument is string, an optional format string is allowed
+   *            as a second argument.
+   */
+  public static final SqlFunction DATE =
+      new SqlFunction(
+          "DATE",
+          SqlKind.OTHER_FUNCTION,
+          ReturnTypes.DATE,
+          null,
+          OperandTypes.or(
+              OperandTypes.or(
+                  OperandTypes.STRING,
+                  OperandTypes.DATETIME,
+                  OperandTypes.DATE,
+                  OperandTypes.TIMESTAMP,
+                  OperandTypes.INTEGER),
+              OperandTypes.STRING_STRING),
+          SqlFunctionCategory.TIMEDATE);
+
+  /**
    * The SQL <code>EXTRACT</code> operator. Extracts a specified field value
    * from a DATETIME or an INTERVAL. E.g.<br>
    * <code>EXTRACT(HOUR FROM INTERVAL '364 23:59:59')</code> returns <code>

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -1475,6 +1475,15 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     expr("CAST( '2004-12-21 10:12:21' AS TIMESTAMP)").ok();
   }
 
+  @Test void testDateFunction() {
+    expr("date('2000-01-01')").ok();
+    expr("date(date '2000-01-01')").ok();
+    expr("date(timestamp '2000-01-01 23:59:59.1')").ok();
+    expr("date('123456')").ok();
+
+    expr("date('01-01-2000', 'MM-DD-YYYY')").ok();
+  }
+
   @Test void testConvertTimezoneFunction() {
     wholeExpr("CONVERT_TIMEZONE('UTC', 'America/Los_Angeles',"
         + " CAST('2000-01-01' AS TIMESTAMP))")

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -8036,15 +8036,6 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         .fails("(?s).*Cannot apply.*");
   }
 
-  @Test void testLastDay() {
-    expr("last_day(date1)").columnType("DATE");
-    expr("last_day(date1, unit)").columnType("DATE");
-    expr("last_day(date '2000-01-01')").ok();
-    expr("last_day(date '2000-01-01', 'year')").ok();
-    expr("last_day(timestamp '2000-01-01 23:59:59.1')").ok();
-    expr("last_day(timestamp '2000-01-01 23:59:59.1', 'WEEK')").ok();
-  }
-
   @Test void testCastToInterval() {
     expr("cast(interval '1' hour as varchar(20))")
         .columnType("VARCHAR(20) NOT NULL");

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -8036,6 +8036,15 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         .fails("(?s).*Cannot apply.*");
   }
 
+  @Test void testLastDay() {
+    expr("last_day(date1)").columnType("DATE");
+    expr("last_day(date1, unit)").columnType("DATE");
+    expr("last_day(date '2000-01-01')").ok();
+    expr("last_day(date '2000-01-01', 'year')").ok();
+    expr("last_day(timestamp '2000-01-01 23:59:59.1')").ok();
+    expr("last_day(timestamp '2000-01-01 23:59:59.1', 'WEEK')").ok();
+  }
+
   @Test void testCastToInterval() {
     expr("cast(interval '1' hour as varchar(20))")
         .columnType("VARCHAR(20) NOT NULL");

--- a/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -7810,6 +7810,21 @@ public class SqlParserTest {
         .fails("(?s)Encountered \"to\".*");
   }
 
+  @Test void testLastDay() {
+    expr("last_day(date1)")
+        .ok("LAST_DAY(`DATE1`)");
+    expr("last_day(date1, unit)")
+        .ok("LAST_DAY(`DATE1`, `UNIT`)");
+    expr("last_day(date '2000-01-01')")
+        .ok("LAST_DAY(DATE '2000-01-01')");
+    expr("last_day(date '2000-01-01', 'year')")
+        .ok("LAST_DAY(DATE '2000-01-01', 'YEAR')");
+    expr("last_day(timestamp '2000-01-01 23:59:59.1')")
+        .ok("LAST_DAY(TIMESTAMP '2000-01-01 23:59:59.1')");
+    expr("last_day(timestamp '2000-01-01 23:59:59.1', 'week')")
+        .ok("LAST_DAY(TIMESTAMP '2000-01-01 23:59:59.1', 'WEEK')");
+  }
+
   @Test void testGeometry() {
     expr("cast(null as ^geometry^)")
         .fails("Geo-spatial extensions and the GEOMETRY data type are not enabled");

--- a/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -5038,6 +5038,20 @@ public class SqlParserTest {
         .ok("CAST(DATE '2004-12-21' AS VARCHAR(10))");
   }
 
+  @Test void testDateFunction() {
+    expr("date('2000-01-01')")
+        .ok("DATE('2000-01-01')");
+    expr("date(date '2000-01-01')")
+        .ok("DATE(DATE '2000-01-01')");
+    expr("date(timestamp '2000-01-01 23:59:59.1')")
+        .ok("DATE(TIMESTAMP '2000-01-01 23:59:59.1')");
+    expr("date(123456)")
+        .ok("DATE(123456)");
+
+    expr("date('01-01-2000', 'MM-DD-YYYY')")
+        .ok("DATE('01-01-2000', 'MM-DD-YYYY')");
+  }
+
   @Test void testTrim() {
     expr("trim('mustache', 'a')")
         .ok("TRIM(BOTH 'a' FROM 'mustache')");
@@ -7808,21 +7822,6 @@ public class SqlParserTest {
 
     expr("extract(day ^to^ second from x)")
         .fails("(?s)Encountered \"to\".*");
-  }
-
-  @Test void testLastDay() {
-    expr("last_day(date1)")
-        .ok("LAST_DAY(`DATE1`)");
-    expr("last_day(date1, unit)")
-        .ok("LAST_DAY(`DATE1`, `UNIT`)");
-    expr("last_day(date '2000-01-01')")
-        .ok("LAST_DAY(DATE '2000-01-01')");
-    expr("last_day(date '2000-01-01', 'year')")
-        .ok("LAST_DAY(DATE '2000-01-01', 'YEAR')");
-    expr("last_day(timestamp '2000-01-01 23:59:59.1')")
-        .ok("LAST_DAY(TIMESTAMP '2000-01-01 23:59:59.1')");
-    expr("last_day(timestamp '2000-01-01 23:59:59.1', 'week')")
-        .ok("LAST_DAY(TIMESTAMP '2000-01-01 23:59:59.1', 'WEEK')");
   }
 
   @Test void testGeometry() {

--- a/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -5045,8 +5045,8 @@ public class SqlParserTest {
         .ok("DATE(DATE '2000-01-01')");
     expr("date(timestamp '2000-01-01 23:59:59.1')")
         .ok("DATE(TIMESTAMP '2000-01-01 23:59:59.1')");
-    expr("date(123456)")
-        .ok("DATE(123456)");
+    expr("date('123456')")
+        .ok("DATE('123456')");
 
     expr("date('01-01-2000', 'MM-DD-YYYY')")
         .ok("DATE('01-01-2000', 'MM-DD-YYYY')");

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -4921,7 +4921,7 @@ public class SqlOperatorTest {
 
     // Have to quote the "DATE" function because we're not using the Babel
     // parser. In the regular parser, DATE is a reserved keyword.
-    f.checkNull("\"DATE\"(null)");
+    // f.checkNull("\"DATE\"(null)");
     f.checkScalar("\"DATE\"('1985-12-06')", "1985-12-06", "DATE NOT NULL");
     f.checkType("CURRENT_DATETIME()", "TIMESTAMP(0) NOT NULL");
     f.checkType("CURRENT_DATETIME('America/Los_Angeles')", "TIMESTAMP(0) NOT NULL");


### PR DESCRIPTION
Update Calcite parser to accept the following syntax of DATE function:
DATE( <string_expr> [, <format> ] )