### PR TITLE
[BE-4579] Fixes Qualify plan gen

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -774,6 +774,19 @@ public class SqlToRelConverter {
         cluster.traitSet().canonize(RelCollations.of(collationList));
 
 
+    /** The behavior of QUALIFY is the same as if you were to add the window function condition
+     * to the select statement, and then add a wrapping query that filters by the result. See
+     * https://docs.snowflake.com/en/sql-reference/constructs/qualify.html
+     * Therefore, we generate an equivalent plan by adding the value to the selectList, and
+     * then generating a wrapping filter immediatly after in handleQualifyClause.
+     */
+    int qualifyInsertionIdx = -1;
+    if (select.getQualify() != null) {
+      qualifyInsertionIdx = select.getSelectList().size();
+      SqlNodeList selectList = select.getSelectList();
+      selectList.add(select.getQualify());
+    }
+
     if (validator().isAggregate(select)) {
       convertAgg(
           bb,
@@ -787,7 +800,7 @@ public class SqlToRelConverter {
     }
 
     if (select.getQualify() != null) {
-      handleQualifyClause(bb);
+      handleQualifyClause(bb, qualifyInsertionIdx);
     }
 
     if (select.isDistinct()) {
@@ -834,15 +847,14 @@ public class SqlToRelConverter {
    * @param bb               Blackboard
    */
   private void handleQualifyClause(
-      Blackboard bb) {
+      Blackboard bb, int qualifyInsertionIdx) {
     RelNode rel = bb.root();
-    // If we had a qualify clause, we know it's the last item in the select list,
-    // as we place it there.
 
     final List<RelDataTypeField> fields = rel.getRowType().getFieldList();
-    final RexNode filterVal = RexInputRef.of(fields.size() - 1, fields);
+    final RexNode filterVal = RexInputRef.of(qualifyInsertionIdx, fields);
+    //fields.size() - 1
 
-    // I'm not entirly certain why we do this, but the normal path that handles WHERE does this,
+    // I'm not entirely certain why we do this, but the normal path that handles WHERE does this,
     // So I'm going to leave it.
     final RexNode filterValWithoutNullability = RexUtil.removeNullabilityCast(typeFactory,
         filterVal);
@@ -871,7 +883,8 @@ public class SqlToRelConverter {
     // TODO: this only needs to happen if this is the topmost node, otherwise
     // we can just leave the column in, and it will likely be projected away at a later step
     final List<Pair<RexNode, String>> newProjects = new ArrayList<>();
-    for (int i = 0; i < fields.size() - 1; i++) {
+    for (int i = 0; i < fields.size(); i++) {
+      if (i == qualifyInsertionIdx) continue;
       newProjects.add(RexInputRef.of2(i, fields));
     }
     final RelNode projectRel = LogicalProject.create(filterRelNode, ImmutableList.of(),
@@ -3570,6 +3583,8 @@ public class SqlToRelConverter {
    * @param bb            Scope within which to resolve identifiers
    * @param select        Query
    * @param orderExprList Additional expressions needed to implement ORDER BY
+   * @return If the select list contains a QUALIFY statement, the index in the
+   * select list where the QUALIFY clause. Otherwise, -1.
    */
   protected void convertAgg(
       Blackboard bb,
@@ -3579,17 +3594,6 @@ public class SqlToRelConverter {
     SqlNodeList groupList = select.getGroup();
     SqlNodeList selectList = select.getSelectList();
 
-    /** The behavior of QUALIFY is the same as if you were to add the window function condition
-     * to the select statement, and then add wrapping query that filters by the result. See
-     * https://docs.snowflake.com/en/sql-reference/constructs/qualify.html
-     * Therefore, we generate an equivalent plan by adding the value to the selectList, and
-     * later generating a wrapping filter in handleQualifyClause, assuming that the clause is
-     * always present as the rightmost element of the selectlist
-     */
-
-    if (select.getQualify() != null) {
-      selectList.add(select.getQualify());
-    }
     SqlNode having = select.getHaving();
 
     final AggConverter aggConverter = new AggConverter(bb, select);
@@ -5461,23 +5465,9 @@ public class SqlToRelConverter {
       Blackboard bb,
       SqlSelect select,
       List<SqlNode> orderList) {
+
     SqlNodeList selectList = select.getSelectList();
-
-    /** The behavior of QUALIFY is the same as if you were to add the window function condition
-     * to the select statement, and then add wrapping query that filters by the result. See
-     * https://docs.snowflake.com/en/sql-reference/constructs/qualify.html
-     * Therefore, we generate an equivalent plan by adding the value to the selectList, and
-     * later generating a wrapping filter in handleQualifyClause, assuming that the clause is
-     * always present as the rightmost element of the selectList
-     */
-    if (select.getQualify() != null) {
-      selectList.add(select.getQualify());
-    }
-
     selectList = validator().expandStar(selectList, select, false);
-
-
-
     replaceSubQueries(bb, selectList, RelOptUtil.Logic.TRUE_FALSE_UNKNOWN);
 
     List<String> fieldNames = new ArrayList<>();

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -851,8 +851,9 @@ public class SqlToRelConverter {
     RelNode rel = bb.root();
 
     final List<RelDataTypeField> fields = rel.getRowType().getFieldList();
+    assert 0 <= qualifyInsertionIdx
+        && qualifyInsertionIdx < fields.size() : "Invalid Qualify Insertion index";
     final RexNode filterVal = RexInputRef.of(qualifyInsertionIdx, fields);
-    //fields.size() - 1
 
     // I'm not entirely certain why we do this, but the normal path that handles WHERE does this,
     // So I'm going to leave it.
@@ -884,7 +885,9 @@ public class SqlToRelConverter {
     // we can just leave the column in, and it will likely be projected away at a later step
     final List<Pair<RexNode, String>> newProjects = new ArrayList<>();
     for (int i = 0; i < fields.size(); i++) {
-      if (i == qualifyInsertionIdx) continue;
+      if (i == qualifyInsertionIdx) {
+        continue;
+      }
       newProjects.add(RexInputRef.of2(i, fields));
     }
     final RelNode projectRel = LogicalProject.create(filterRelNode, ImmutableList.of(),
@@ -3583,8 +3586,6 @@ public class SqlToRelConverter {
    * @param bb            Scope within which to resolve identifiers
    * @param select        Query
    * @param orderExprList Additional expressions needed to implement ORDER BY
-   * @return If the select list contains a QUALIFY statement, the index in the
-   * select list where the QUALIFY clause. Otherwise, -1.
    */
   protected void convertAgg(
       Blackboard bb,

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -3875,6 +3875,20 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
     sql(sql1).ok();
   }
 
+  @Test void testQualifyOrderBy() {
+    //Tests a basic INSERT query with some implicit conversion
+    final String sql1 = "" +
+        "SELECT\n" +
+        "    empno\n" +
+        "FROM emp\n" +
+        "QUALIFY ROW_NUMBER() OVER(\n" +
+        "  PARTITION BY\n" +
+        "      empno\n" +
+        ") = 1\n" +
+        "ORDER BY ename";
+
+    sql(sql1).ok();
+  }
 
 
   @Test void testInsertImplicitConversion() {

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -3877,14 +3877,20 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
 
   @Test void testQualifyOrderBy() {
     //Tests a basic INSERT query with some implicit conversion
-    final String sql1 = "" +
-        "SELECT\n" +
-        "    empno\n" +
-        "FROM emp\n" +
-        "QUALIFY ROW_NUMBER() OVER(\n" +
-        "  PARTITION BY\n" +
-        "      empno\n" +
-        ") = 1\n" +
+    final String sql1 = "SELECT\n"
+        +
+        "    empno\n"
+        +
+        "FROM emp\n"
+        +
+        "QUALIFY ROW_NUMBER() OVER(\n"
+        +
+        "  PARTITION BY\n"
+        +
+        "      empno\n"
+        +
+        ") = 1\n"
+        +
         "ORDER BY ename";
 
     sql(sql1).ok();

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -7615,6 +7615,18 @@ LogicalProject(DEPTNO=[$0])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testQualifyOrderBy">
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(EMPNO=[$0])
+  LogicalSort(sort0=[$1], dir0=[ASC])
+    LogicalProject(EMPNO=[$0], ENAME=[$2])
+      LogicalFilter(condition=[$1])
+        LogicalProject(EMPNO=[$0], EXPR$1=[=(ROW_NUMBER() OVER (PARTITION BY $0), 1)], ENAME=[$1])
+          LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testQualifySubquerySimple">
     <Resource name="sql">
       <![CDATA[SELECT empno FROM emp QUALIFY ROW_NUMBER() over (PARTITION BY deptno ORDER BY sal) in (SELECT deptno from emp)]]>


### PR DESCRIPTION
When writing the Qualify plan gen, I made a faulty assumption that the Filter expression would always be the last element of the converted select list. However, this is not true in the case that the select contains an Order By clause.