### PR TITLE
Group by ordinals are now recursively expanded to resolve aliases

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -8183,7 +8183,12 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
 
             // SQL ordinals are 1-based, but Sort's are 0-based
             int ordinal = intValue - 1;
-            return SqlUtil.stripAs(SqlNonNullableAccessors.getSelectList(select).get(ordinal));
+            SqlNode expr = SqlUtil.stripAs(
+                SqlNonNullableAccessors.getSelectList(select).get(ordinal));
+            if (!(expr instanceof SqlLiteral)) {
+              expr = expr.accept(this);
+            }
+            return expr;
           }
           break;
         default:

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -7112,6 +7112,13 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     sql("select deptno from emp group by ^100^, deptno")
         .withConformance(lenient).fails("Ordinal out of range")
         .withConformance(strict).ok();
+    // Recursive expansion of group by ordinals.
+    // Function here doesn't matter just needs to be a function.
+    sql("select deptno as x, sqrt(x) as y, count(*) from emp group by 1, 2")
+        // The identifier lookups for other elements in the select list are
+        // presently bugged and don't work properly when identifier expansion is off.
+        .withValidatorIdentifierExpansion(true)
+        .withConformance(lenient).ok();
   }
 
   /**


### PR DESCRIPTION
When group by ordinals were replaced, they were not expanded recursively
so if an alias appeared in a function call it would not be expanded to
the proper identifier. This caused validation to fail with a column not
found.