### PR TITLE
[BSE-48] Support for Transient/Temporary table

### DIFF
--- a/bodo/src/test/java/org/apache/calcite/test/BodoSqlToRelConverterTest.java
+++ b/bodo/src/test/java/org/apache/calcite/test/BodoSqlToRelConverterTest.java
@@ -45,7 +45,6 @@ public class BodoSqlToRelConverterTest extends SqlToRelTestBase {
     sql(sql).ok();
   }
 
-
   @Test void testCreateTableSimple() {
     // Simple test to confirm that we can handle create table statements
     final String sql = "CREATE TABLE out_test AS select 1, 2, 3 from emp";

--- a/bodo/src/test/resources/org/apache/calcite/test/BodoSqlToRelConverterTest.xml
+++ b/bodo/src/test/resources/org/apache/calcite/test/BodoSqlToRelConverterTest.xml
@@ -19,7 +19,7 @@
   <TestCase name="testCreateIfNotExistsTableLike">
     <Resource name="plan">
       <![CDATA[
-LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[CUSTOMER]], IsReplace=[false])
+LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[CUSTOMER]], IsReplace=[false], CreateTableType=[PERMANENT])
   LogicalSort(fetch=[0:BIGINT])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
@@ -28,7 +28,7 @@ LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[CUSTOMER]], IsReplace=[
   <TestCase name="testCreateOrReplaceTable">
     <Resource name="plan">
       <![CDATA[
-LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[CUSTOMER]], IsReplace=[true])
+LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[CUSTOMER]], IsReplace=[true], CreateTableType=[PERMANENT])
   LogicalProject(DEPTNO=[$9], EMPNO=[$0])
     LogicalJoin(condition=[=($7, $9)], joinType=[inner])
       LogicalTableScan(table=[[CATALOG, SALES, EMP]])
@@ -44,7 +44,7 @@ select dept.deptno, emp.empno
   <TestCase name="testCreateOrReplaceTableLike">
     <Resource name="plan">
       <![CDATA[
-LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[CUSTOMER]], IsReplace=[true])
+LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[CUSTOMER]], IsReplace=[true], CreateTableType=[PERMANENT])
   LogicalSort(fetch=[0:BIGINT])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
@@ -53,7 +53,7 @@ LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[CUSTOMER]], IsReplace=[
   <TestCase name="testCreateTableIfNotExists">
     <Resource name="plan">
       <![CDATA[
-LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[SALES]], IsReplace=[false])
+LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[SALES]], IsReplace=[false], CreateTableType=[PERMANENT])
   LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
@@ -65,7 +65,7 @@ LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[SALES]], IsReplace=[fal
   <TestCase name="testCreateTableLike">
     <Resource name="plan">
       <![CDATA[
-LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[CUSTOMER]], IsReplace=[false])
+LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[CUSTOMER]], IsReplace=[false], CreateTableType=[PERMANENT])
   LogicalSort(fetch=[0:BIGINT])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
@@ -74,7 +74,7 @@ LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[CUSTOMER]], IsReplace=[
   <TestCase name="testCreateTableOrderBy">
     <Resource name="plan">
       <![CDATA[
-LogicalTableCreate(TableName=[TESTING_OUTPUT], Target Schema=[[SALES]], IsReplace=[false])
+LogicalTableCreate(TableName=[TESTING_OUTPUT], Target Schema=[[SALES]], IsReplace=[false], CreateTableType=[PERMANENT])
   LogicalSort(sort0=[$0], dir0=[ASC])
     LogicalProject(P_PARTKEY=[$0])
       LogicalValues(tuples=[[{ 'foo' }]])
@@ -84,7 +84,7 @@ LogicalTableCreate(TableName=[TESTING_OUTPUT], Target Schema=[[SALES]], IsReplac
   <TestCase name="testCreateTableRewrite">
     <Resource name="plan">
       <![CDATA[
-LogicalTableCreate(TableName=[FOO], Target Schema=[[SALES]], IsReplace=[false])
+LogicalTableCreate(TableName=[FOO], Target Schema=[[SALES]], IsReplace=[false], CreateTableType=[PERMANENT])
   LogicalSort(fetch=[10])
     LogicalProject(DEPTNO=[$0], NAME=[$1])
       LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
@@ -97,7 +97,7 @@ LogicalTableCreate(TableName=[FOO], Target Schema=[[SALES]], IsReplace=[false])
   <TestCase name="testCreateTableSimple">
     <Resource name="plan">
       <![CDATA[
-LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[SALES]], IsReplace=[false])
+LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[SALES]], IsReplace=[false], CreateTableType=[PERMANENT])
   LogicalProject(EXPR$0=[1], EXPR$1=[2], EXPR$2=[3])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
@@ -106,7 +106,7 @@ LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[SALES]], IsReplace=[fal
   <TestCase name="testCreateTableWith">
     <Resource name="plan">
       <![CDATA[
-LogicalTableCreate(TableName=[FOO], Target Schema=[[SALES]], IsReplace=[false])
+LogicalTableCreate(TableName=[FOO], Target Schema=[[SALES]], IsReplace=[false], CreateTableType=[PERMANENT])
   LogicalProject(DEPTNO=[$0], NAME=[$1], DEPTNO0=[$2], NAME0=[$3])
     LogicalJoin(condition=[=($0, $2)], joinType=[inner])
       LogicalSort(fetch=[10])

--- a/bodo/src/test/resources/org/apache/calcite/test/BodoSqlToRelConverterTest.xml
+++ b/bodo/src/test/resources/org/apache/calcite/test/BodoSqlToRelConverterTest.xml
@@ -19,7 +19,7 @@
   <TestCase name="testCreateIfNotExistsTableLike">
     <Resource name="plan">
       <![CDATA[
-LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[CUSTOMER]], IsReplace=[false], CreateTableType=[PERMANENT])
+LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[CUSTOMER]], IsReplace=[false], CreateTableType=[DEFAULT])
   LogicalSort(fetch=[0:BIGINT])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
@@ -28,7 +28,7 @@ LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[CUSTOMER]], IsReplace=[
   <TestCase name="testCreateOrReplaceTable">
     <Resource name="plan">
       <![CDATA[
-LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[CUSTOMER]], IsReplace=[true], CreateTableType=[PERMANENT])
+LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[CUSTOMER]], IsReplace=[true], CreateTableType=[DEFAULT])
   LogicalProject(DEPTNO=[$9], EMPNO=[$0])
     LogicalJoin(condition=[=($7, $9)], joinType=[inner])
       LogicalTableScan(table=[[CATALOG, SALES, EMP]])
@@ -44,7 +44,7 @@ select dept.deptno, emp.empno
   <TestCase name="testCreateOrReplaceTableLike">
     <Resource name="plan">
       <![CDATA[
-LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[CUSTOMER]], IsReplace=[true], CreateTableType=[PERMANENT])
+LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[CUSTOMER]], IsReplace=[true], CreateTableType=[DEFAULT])
   LogicalSort(fetch=[0:BIGINT])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
@@ -53,7 +53,7 @@ LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[CUSTOMER]], IsReplace=[
   <TestCase name="testCreateTableIfNotExists">
     <Resource name="plan">
       <![CDATA[
-LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[SALES]], IsReplace=[false], CreateTableType=[PERMANENT])
+LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[SALES]], IsReplace=[false], CreateTableType=[DEFAULT])
   LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
@@ -65,7 +65,7 @@ LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[SALES]], IsReplace=[fal
   <TestCase name="testCreateTableLike">
     <Resource name="plan">
       <![CDATA[
-LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[CUSTOMER]], IsReplace=[false], CreateTableType=[PERMANENT])
+LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[CUSTOMER]], IsReplace=[false], CreateTableType=[DEFAULT])
   LogicalSort(fetch=[0:BIGINT])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
@@ -74,7 +74,7 @@ LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[CUSTOMER]], IsReplace=[
   <TestCase name="testCreateTableOrderBy">
     <Resource name="plan">
       <![CDATA[
-LogicalTableCreate(TableName=[TESTING_OUTPUT], Target Schema=[[SALES]], IsReplace=[false], CreateTableType=[PERMANENT])
+LogicalTableCreate(TableName=[TESTING_OUTPUT], Target Schema=[[SALES]], IsReplace=[false], CreateTableType=[DEFAULT])
   LogicalSort(sort0=[$0], dir0=[ASC])
     LogicalProject(P_PARTKEY=[$0])
       LogicalValues(tuples=[[{ 'foo' }]])
@@ -84,7 +84,7 @@ LogicalTableCreate(TableName=[TESTING_OUTPUT], Target Schema=[[SALES]], IsReplac
   <TestCase name="testCreateTableRewrite">
     <Resource name="plan">
       <![CDATA[
-LogicalTableCreate(TableName=[FOO], Target Schema=[[SALES]], IsReplace=[false], CreateTableType=[PERMANENT])
+LogicalTableCreate(TableName=[FOO], Target Schema=[[SALES]], IsReplace=[false], CreateTableType=[DEFAULT])
   LogicalSort(fetch=[10])
     LogicalProject(DEPTNO=[$0], NAME=[$1])
       LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
@@ -97,7 +97,7 @@ LogicalTableCreate(TableName=[FOO], Target Schema=[[SALES]], IsReplace=[false], 
   <TestCase name="testCreateTableSimple">
     <Resource name="plan">
       <![CDATA[
-LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[SALES]], IsReplace=[false], CreateTableType=[PERMANENT])
+LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[SALES]], IsReplace=[false], CreateTableType=[DEFAULT])
   LogicalProject(EXPR$0=[1], EXPR$1=[2], EXPR$2=[3])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
@@ -106,7 +106,7 @@ LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[SALES]], IsReplace=[fal
   <TestCase name="testCreateTableWith">
     <Resource name="plan">
       <![CDATA[
-LogicalTableCreate(TableName=[FOO], Target Schema=[[SALES]], IsReplace=[false], CreateTableType=[PERMANENT])
+LogicalTableCreate(TableName=[FOO], Target Schema=[[SALES]], IsReplace=[false], CreateTableType=[DEFAULT])
   LogicalProject(DEPTNO=[$0], NAME=[$1], DEPTNO0=[$2], NAME0=[$3])
     LogicalJoin(condition=[=($0, $2)], joinType=[inner])
       LogicalSort(fetch=[10])

--- a/core/src/main/java/org/apache/calcite/rel/core/LogicalTableCreate.java
+++ b/core/src/main/java/org/apache/calcite/rel/core/LogicalTableCreate.java
@@ -22,6 +22,7 @@ import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelWriter;
 import org.apache.calcite.schema.Schema;
+import org.apache.calcite.sql.ddl.SqlCreateTable;
 
 import java.util.List;
 
@@ -36,6 +37,8 @@ public class LogicalTableCreate extends TableCreate {
   private final String tableName;
   private final boolean isReplace;
 
+  private final SqlCreateTable.CreateTableType createTableType;
+
   /**
    * Creates a LogicaltableCreate Node.
    *
@@ -45,31 +48,34 @@ public class LogicalTableCreate extends TableCreate {
    */
   protected LogicalTableCreate(final RelOptCluster cluster, final RelTraitSet traits,
       final RelNode input, final Schema schema, final String tableName,
-      final boolean isReplace, final List<String> path) {
+      final boolean isReplace, final SqlCreateTable.CreateTableType createTableType,
+      final List<String> path) {
     super(cluster, traits, input);
     this.schema = schema;
     this.tableName = tableName;
     this.isReplace = isReplace;
     this.schemaPath = path;
+    this.createTableType = createTableType;
   }
 
   /** Creates a LogicalTableModify. */
   public static LogicalTableCreate create(final RelNode input,
       final Schema schema, final String tableName,
-      final boolean isReplace, final List<String> path) {
-
+      final boolean isReplace, final SqlCreateTable.CreateTableType createTableType,
+      final List<String> path) {
 
     final RelOptCluster cluster = input.getCluster();
     final RelTraitSet traitSet = cluster.traitSetOf(Convention.NONE);
     return new LogicalTableCreate(cluster, traitSet, input, schema, tableName,
-        isReplace, path);
+        isReplace, createTableType, path);
   }
 
   @Override public RelWriter explainTerms(RelWriter pw) {
     return super.explainTerms(pw)
         .item("TableName", this.tableName)
         .item("Target Schema", this.schemaPath)
-        .item("IsReplace", this.isReplace);
+        .item("IsReplace", this.isReplace)
+        .item("CreateTableType", this.createTableType);
   }
 
   public Schema getSchema() {
@@ -78,6 +84,10 @@ public class LogicalTableCreate extends TableCreate {
 
   public String getTableName() {
     return tableName;
+  }
+
+  public SqlCreateTable.CreateTableType getCreateTableType() {
+    return createTableType;
   }
 
   public boolean isReplace() {
@@ -90,7 +100,7 @@ public class LogicalTableCreate extends TableCreate {
     assert inputs.size() == 1;
     return new LogicalTableCreate(
         getCluster(), traitSet, inputs.get(0), this.schema, this.tableName,
-        this.isReplace, this.schemaPath);
+        this.isReplace, this.createTableType, this.schemaPath);
   }
 
   public List<String> getSchemaPath() {

--- a/core/src/main/java/org/apache/calcite/sql/ddl/SqlCreateTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/ddl/SqlCreateTable.java
@@ -52,7 +52,7 @@ public class SqlCreateTable extends SqlCreate {
   private @Nullable Schema outputTableSchema;
   private @Nullable List<String> outputTableSchemaPath;
 
-  private CreateTableType createType;
+  protected CreateTableType createType;
 
   /** Enum describing the possible types of output table.
    * This should be reverted/moved to the bodo create table SqlNode

--- a/core/src/main/java/org/apache/calcite/sql/ddl/SqlCreateTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/ddl/SqlCreateTable.java
@@ -52,6 +52,19 @@ public class SqlCreateTable extends SqlCreate {
   private @Nullable Schema outputTableSchema;
   private @Nullable List<String> outputTableSchemaPath;
 
+  private CreateTableType createType;
+
+  /** Enum describing the possible types of output table.
+   * This should be reverted/moved to the bodo create table SqlNode
+   * when we rewrite createRelationalAlgebraHandler to handle
+   * DDL statements prior to SqlToRel conversion.
+   */
+  public enum CreateTableType {
+    PERMANENT,
+    TEMPORARY,
+    TRANSIENT;
+  }
+
   private static final SqlOperator OPERATOR =
       new SqlSpecialOperator("CREATE TABLE", SqlKind.CREATE_TABLE);
 
@@ -62,6 +75,7 @@ public class SqlCreateTable extends SqlCreate {
     this.name = Objects.requireNonNull(name, "name");
     this.columnList = columnList; // may be null
     this.query = query; // for "CREATE TABLE ... AS query"; may be null
+    this.createType = CreateTableType.PERMANENT; // To handle CREATE [TEMPORARY/PERMANENT/..] TABLE
   }
 
   @SuppressWarnings("nullness")
@@ -149,4 +163,7 @@ public class SqlCreateTable extends SqlCreate {
     return outputTableName;
   }
 
+  public CreateTableType getCreateTableType() {
+    return this.createType;
+  }
 }

--- a/core/src/main/java/org/apache/calcite/sql/ddl/SqlCreateTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/ddl/SqlCreateTable.java
@@ -64,6 +64,8 @@ public class SqlCreateTable extends SqlCreate {
     TEMPORARY,
     TRANSIENT;
 
+    //Helper function to convert the enum to string. Used in the BodoSQL repo when generating
+    //text
     public String asStringKeyword() {
       switch (this) {
       case TEMPORARY:

--- a/core/src/main/java/org/apache/calcite/sql/ddl/SqlCreateTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/ddl/SqlCreateTable.java
@@ -60,9 +60,23 @@ public class SqlCreateTable extends SqlCreate {
    * DDL statements prior to SqlToRel conversion.
    */
   public enum CreateTableType {
-    PERMANENT,
+    DEFAULT,
     TEMPORARY,
     TRANSIENT;
+
+    public String asStringKeyword() {
+      switch (this) {
+      case TEMPORARY:
+        return "TEMPORARY";
+      case TRANSIENT:
+        return "TRANSIENT";
+      case DEFAULT:
+        return "";
+      default:
+        throw new RuntimeException("Reached unreachable code in CreateTableType.asStringKeyword");
+      }
+    }
+
   }
 
   private static final SqlOperator OPERATOR =
@@ -75,7 +89,7 @@ public class SqlCreateTable extends SqlCreate {
     this.name = Objects.requireNonNull(name, "name");
     this.columnList = columnList; // may be null
     this.query = query; // for "CREATE TABLE ... AS query"; may be null
-    this.createType = CreateTableType.PERMANENT; // To handle CREATE [TEMPORARY/PERMANENT/..] TABLE
+    this.createType = CreateTableType.DEFAULT; // To handle CREATE [TEMPORARY/TRANSIENT/..] TABLE
   }
 
   @SuppressWarnings("nullness")

--- a/core/src/main/java/org/apache/calcite/sql2rel/RelStructuredTypeFlattener.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/RelStructuredTypeFlattener.java
@@ -411,6 +411,7 @@ public class RelStructuredTypeFlattener implements ReflectiveVisitor {
             rel.getSchema(),
             rel.getTableName(),
             rel.isReplace(),
+            rel.getCreateTableType(),
             rel.getSchemaPath()
         );
     setNewForOldRel(rel, newRel);

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -4578,6 +4578,7 @@ public class SqlToRelConverter {
         // Failing if already exists is the default in SF
         // TODO: support a dialect dependent default if/when merging to upstream Calcite
         call.getReplace(),
+        call.getCreateTableType(),
         requireNonNull(call.getOutputTableSchemaPath()));
   }
 


### PR DESCRIPTION
Associated Bodo PR: https://github.com/Bodo-inc/Bodo/pull/5247

Adds TEMPORARY/TRANSIENT/PERMANENT fields to the base SqlCreateTable node, and handles the SqlToRel conversion. This may be refactored if we later choose to handle DDL nodes at the SQL level (https://bodo.atlassian.net/wiki/spaces/~787862068/pages/1343848464/DDL+rewrite+WIP). 