### PR TITLE
[BSE-122] Add create_table to the DML SqlKind Set and set the output type for create table

### DIFF
--- a/bodo/src/test/java/org/apache/calcite/test/BodoSqlToRelConverterTest.java
+++ b/bodo/src/test/java/org/apache/calcite/test/BodoSqlToRelConverterTest.java
@@ -66,6 +66,13 @@ public class BodoSqlToRelConverterTest extends SqlToRelTestBase {
     sql(sql).withExtendedTester().ok();
   }
 
+  @Test void testCreateTableOrderByExpr() {
+    // Test where create table has an order by operation that generates additional columns
+    final String sql = "CREATE TABLE out_test as select emp.empno from emp "
+        + "order by emp.empno is not null";
+    sql(sql).ok();
+  }
+
 
 
   @Test void testCreateTableRewrite() {

--- a/bodo/src/test/resources/org/apache/calcite/test/BodoSqlToRelConverterTest.xml
+++ b/bodo/src/test/resources/org/apache/calcite/test/BodoSqlToRelConverterTest.xml
@@ -24,6 +24,10 @@ LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[CUSTOMER]], IsReplace=[
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
     </Resource>
+    <Resource name="sql">
+      <![CDATA[CREATE TABLE IF NOT EXISTS CUSTOMER.out_test LIKE
+emp]]>
+    </Resource>
   </TestCase>
   <TestCase name="testCreateOrReplaceTable">
     <Resource name="plan">
@@ -48,6 +52,10 @@ LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[CUSTOMER]], IsReplace=[
   LogicalSort(fetch=[0:BIGINT])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
+    </Resource>
+    <Resource name="sql">
+      <![CDATA[CREATE OR REPLACE TABLE CUSTOMER.out_test LIKE
+emp]]>
     </Resource>
   </TestCase>
   <TestCase name="testCreateTableIfNotExists">
@@ -80,6 +88,31 @@ LogicalTableCreate(TableName=[TESTING_OUTPUT], Target Schema=[[SALES]], IsReplac
       LogicalValues(tuples=[[{ 'foo' }]])
 ]]>
     </Resource>
+    <Resource name="sql">
+      <![CDATA[CREATE TABLE testing_output AS (with part_two as (
+        select 'foo' as p_partkey from (VALUES (1, 2, 3))
+    )
+    select
+                       p_partkey
+                     from
+                       part_two
+                     order by
+                       p_partkey)]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCreateTableOrderByExpr">
+    <Resource name="plan">
+      <![CDATA[
+LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[SALES]], IsReplace=[false], CreateTableType=[DEFAULT])
+  LogicalProject(EMPNO=[$0])
+    LogicalSort(sort0=[$1], dir0=[ASC])
+      LogicalProject(EMPNO=[$0], EXPR$1=[true])
+        LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="sql">
+      <![CDATA[CREATE TABLE out_test as select emp.empno from emp order by emp.empno is not null]]>
+    </Resource>
   </TestCase>
   <TestCase name="testCreateTableRewrite">
     <Resource name="plan">
@@ -101,6 +134,9 @@ LogicalTableCreate(TableName=[OUT_TEST], Target Schema=[[SALES]], IsReplace=[fal
   LogicalProject(EXPR$0=[1], EXPR$1=[2], EXPR$2=[3])
     LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
+    </Resource>
+    <Resource name="sql">
+      <![CDATA[CREATE TABLE out_test AS select 1, 2, 3 from emp]]>
     </Resource>
   </TestCase>
   <TestCase name="testCreateTableWith">
@@ -132,6 +168,17 @@ LogicalSort(sort0=[$0], dir0=[ASC])
   LogicalProject(P_PARTKEY=[$0])
     LogicalValues(tuples=[[{ 'foo' }]])
 ]]>
+    </Resource>
+    <Resource name="sql">
+      <![CDATA[with part_two as (
+        select 'foo' as p_partkey from (VALUES (1, 2, 3))
+    )
+    select
+                       p_partkey
+                     from
+                       part_two
+                     order by
+                       p_partkey]]>
     </Resource>
   </TestCase>
   <TestCase name="testValueUnreserved">

--- a/core/src/main/java/org/apache/calcite/sql/SqlKind.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlKind.java
@@ -1123,6 +1123,7 @@ public enum SqlKind {
    * {@link #DELETE},
    * {@link #MERGE},
    * {@link #PROCEDURE_CALL}.
+   * {@link #CREATE_TABLE}
    *
    * <p>NOTE jvs 1-June-2006: For now we treat procedure calls as DML;
    * this makes it easy for JDBC clients to call execute or
@@ -1131,7 +1132,7 @@ public enum SqlKind {
    * we'll need to refine this.
    */
   public static final EnumSet<SqlKind> DML =
-      EnumSet.of(INSERT, DELETE, UPDATE, MERGE, PROCEDURE_CALL);
+      EnumSet.of(INSERT, DELETE, UPDATE, MERGE, PROCEDURE_CALL, CREATE_TABLE);
 
   /**
    * Category consisting of all DDL operators.

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -4553,10 +4553,9 @@ public class SqlToRelConverter {
     // TLDR: We'd like to set top=False, to enable some optimizations on the plan,
     // but we run into a bug with calcite. For right now, we're just setting top=True,
     // which is always correct, but may result in a less performant plan.
-
-    RelRoot relRoot = convertQueryRecursive(
-        requireNonNull(createTableDef,
-            "createTableDef"), true, null);
+    SqlNode nonNullCreateTableDef = requireNonNull(createTableDef, "createTableDef");
+    RelDataType validatedRowType = this.validator().getValidatedNodeType(nonNullCreateTableDef);
+    RelRoot relRoot = convertQueryRecursive(nonNullCreateTableDef, true, validatedRowType);
     return relRoot.project();
   }
 

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -4557,7 +4557,7 @@ public class SqlToRelConverter {
     RelRoot relRoot = convertQueryRecursive(
         requireNonNull(createTableDef,
             "createTableDef"), true, null);
-    return relRoot.rel;
+    return relRoot.project();
   }
 
   private RelNode convertCreateTableIdentifier(


### PR DESCRIPTION
Adds create_table to the DML Sqlkind set. This is needed for `RelRoot.project` to work. This also uses the validatedRowType from the original create_table to filter its input and prune any intermediate columns.