### PR TITLE
Revert DML change and update project to use DDL

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/RelRoot.java
+++ b/core/src/main/java/org/apache/calcite/rel/RelRoot.java
@@ -157,6 +157,7 @@ public class RelRoot {
   public RelNode project(boolean force) {
     if (isRefTrivial()
         && (SqlKind.DML.contains(kind)
+            || SqlKind.DDL.contains(kind)
             || !force
             || rel instanceof LogicalProject)) {
       return rel;

--- a/core/src/main/java/org/apache/calcite/sql/SqlKind.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlKind.java
@@ -1132,7 +1132,7 @@ public enum SqlKind {
    * we'll need to refine this.
    */
   public static final EnumSet<SqlKind> DML =
-      EnumSet.of(INSERT, DELETE, UPDATE, MERGE, PROCEDURE_CALL, CREATE_TABLE);
+      EnumSet.of(INSERT, DELETE, UPDATE, MERGE, PROCEDURE_CALL);
 
   /**
    * Category consisting of all DDL operators.


### PR DESCRIPTION
Reverts the change to project to be more accurate and exclude DDL statements from generating a projection.