### PR TITLE
Update From additional changes

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlUpdate.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlUpdate.java
@@ -190,6 +190,10 @@ public class SqlUpdate extends SqlCall {
     }
     writer.endList(setFrame);
     SqlNode condition = this.condition;
+    if (fromClause != null) {
+      writer.sep("FROM");
+      fromClause.unparse(writer, opLeft, opRight);
+    }
     if (condition != null) {
       writer.sep("WHERE");
       condition.unparse(writer, opLeft, opRight);

--- a/core/src/main/java/org/apache/calcite/sql/SqlUpdate.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlUpdate.java
@@ -43,7 +43,7 @@ public class SqlUpdate extends SqlCall {
   @Nullable SqlSelect sourceSelect;
   @Nullable SqlIdentifier alias;
 
-  @Nullable SqlNode fromClause;
+  @Nullable SqlNode from;
 
   //~ Constructors -----------------------------------------------------------
 
@@ -62,7 +62,7 @@ public class SqlUpdate extends SqlCall {
     this.sourceSelect = sourceSelect;
     assert sourceExpressionList.size() == targetColumnList.size();
     this.alias = alias;
-    this.fromClause = null;
+    this.from = null;
   }
 
   //~ Methods ----------------------------------------------------------------
@@ -102,6 +102,9 @@ public class SqlUpdate extends SqlCall {
       break;
     case 5:
       alias = (SqlIdentifier) operand;
+      break;
+    case 6:
+      from = from;
       break;
     default:
       throw new AssertionError(i);
@@ -143,12 +146,12 @@ public class SqlUpdate extends SqlCall {
     return condition;
   }
 
-  public @Nullable SqlNode getFromClause() {
-    return fromClause;
+  public @Nullable SqlNode getFrom() {
+    return from;
   }
 
-  public void setFromClause(@Nullable SqlNode from) {
-    this.fromClause = from;
+  public void setFrom(@Nullable SqlNode from) {
+    this.from = from;
   }
 
   /**
@@ -190,9 +193,9 @@ public class SqlUpdate extends SqlCall {
     }
     writer.endList(setFrame);
     SqlNode condition = this.condition;
-    if (fromClause != null) {
+    if (from != null) {
       writer.sep("FROM");
-      fromClause.unparse(writer, opLeft, opRight);
+      from.unparse(writer, opLeft, opRight);
     }
     if (condition != null) {
       writer.sep("WHERE");

--- a/core/src/main/java/org/apache/calcite/sql/SqlUpdate.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlUpdate.java
@@ -104,7 +104,7 @@ public class SqlUpdate extends SqlCall {
       alias = (SqlIdentifier) operand;
       break;
     case 6:
-      from = from;
+      from = operand;
       break;
     default:
       throw new AssertionError(i);

--- a/core/src/main/java/org/apache/calcite/sql/SqlUpdate.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlUpdate.java
@@ -43,7 +43,6 @@ public class SqlUpdate extends SqlCall {
   @Nullable SqlSelect sourceSelect;
   @Nullable SqlIdentifier alias;
 
-  @Nullable SqlNode from;
 
   //~ Constructors -----------------------------------------------------------
 
@@ -62,7 +61,6 @@ public class SqlUpdate extends SqlCall {
     this.sourceSelect = sourceSelect;
     assert sourceExpressionList.size() == targetColumnList.size();
     this.alias = alias;
-    this.from = null;
   }
 
   //~ Methods ----------------------------------------------------------------
@@ -102,9 +100,6 @@ public class SqlUpdate extends SqlCall {
       break;
     case 5:
       alias = (SqlIdentifier) operand;
-      break;
-    case 6:
-      from = operand;
       break;
     default:
       throw new AssertionError(i);
@@ -146,14 +141,6 @@ public class SqlUpdate extends SqlCall {
     return condition;
   }
 
-  public @Nullable SqlNode getFrom() {
-    return from;
-  }
-
-  public void setFrom(@Nullable SqlNode from) {
-    this.from = from;
-  }
-
   /**
    * Gets the source SELECT expression for the data to be updated. Returns
    * null before the statement has been expanded by
@@ -193,10 +180,6 @@ public class SqlUpdate extends SqlCall {
     }
     writer.endList(setFrame);
     SqlNode condition = this.condition;
-    if (from != null) {
-      writer.sep("FROM");
-      from.unparse(writer, opLeft, opRight);
-    }
     if (condition != null) {
       writer.sep("WHERE");
       condition.unparse(writer, opLeft, opRight);

--- a/core/src/main/java/org/apache/calcite/sql/ddl/SqlColumnDeclaration.java
+++ b/core/src/main/java/org/apache/calcite/sql/ddl/SqlColumnDeclaration.java
@@ -48,7 +48,7 @@ public class SqlColumnDeclaration extends SqlCall {
   public final ColumnStrategy strategy;
 
   /** Creates a SqlColumnDeclaration; use {@link SqlDdlNodes#column}. */
-  SqlColumnDeclaration(SqlParserPos pos, SqlIdentifier name,
+  protected SqlColumnDeclaration(SqlParserPos pos, SqlIdentifier name,
       SqlDataTypeSpec dataType, @Nullable SqlNode expression,
       ColumnStrategy strategy) {
     super(pos);

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -1926,7 +1926,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
       // Rewrite A=B, C=D from updates to equality expressipns
       // so that the SELECT validation can check for type safety
       SqlNode target = targetCols.get(ordinal);
-      exp = new SqlBasicCall(SqlStdOperatorTable.EQUALS, List.of(target, exp), SqlParserPos.ZERO);
+      exp = new SqlBasicCall(SqlStdOperatorTable.EQUALS, Arrays.asList(target, exp), SqlParserPos.ZERO);
       // Force unique aliases to avoid a duplicate for Y with
       // SET X=Y
       String alias = SqlUtil.deriveAliasFromOrdinal(ordinal);

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -1923,13 +1923,6 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
     int ordinal = 0;
     SqlNodeList targetCols = call.getTargetColumnList();
     for (SqlNode exp : call.getSourceExpressionList()) {
-      // Rewrite A=B, C=D from updates to equality expressipns
-      // so that the SELECT validation can check for type safety
-      SqlNode target = targetCols.get(ordinal);
-      List<SqlNode> args = new ArrayList<SqlNode>();
-      args.add(target);
-      args.add(exp);
-      exp = new SqlBasicCall(SqlStdOperatorTable.EQUALS, args, SqlParserPos.ZERO);
       // Force unique aliases to avoid a duplicate for Y with
       // SET X=Y
       String alias = SqlUtil.deriveAliasFromOrdinal(ordinal);

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -1921,7 +1921,6 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
     final SqlNodeList selectList = new SqlNodeList(SqlParserPos.ZERO);
     selectList.add(SqlIdentifier.star(SqlParserPos.ZERO));
     int ordinal = 0;
-    SqlNodeList targetCols = call.getTargetColumnList();
     for (SqlNode exp : call.getSourceExpressionList()) {
       // Force unique aliases to avoid a duplicate for Y with
       // SET X=Y
@@ -1931,23 +1930,11 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
     }
     SqlNode sourceTable = call.getTargetTable();
     SqlIdentifier alias = call.getAlias();
-    SqlNode from = call.getFrom();
     if (alias != null) {
       sourceTable =
           SqlValidatorUtil.addAlias(
               sourceTable,
               alias.getSimple());
-    }
-    if (from != null) {
-      sourceTable = new SqlJoin(
-          SqlParserPos.ZERO,
-          sourceTable,
-          SqlLiteral.createBoolean(false, SqlParserPos.ZERO),
-          JoinType.CROSS.symbol(SqlParserPos.ZERO),
-          from,
-          JoinConditionType.NONE.symbol(SqlParserPos.ZERO),
-          null
-      );
     }
     return new SqlSelect(SqlParserPos.ZERO, null, selectList, sourceTable,
         call.getCondition(), null, null, null, null, null, null, null, null);

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -1926,7 +1926,10 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
       // Rewrite A=B, C=D from updates to equality expressipns
       // so that the SELECT validation can check for type safety
       SqlNode target = targetCols.get(ordinal);
-      exp = new SqlBasicCall(SqlStdOperatorTable.EQUALS, Arrays.asList(target, exp), SqlParserPos.ZERO);
+      List<SqlNode> args = new ArrayList<SqlNode>();
+      args.add(target);
+      args.add(exp);
+      exp = new SqlBasicCall(SqlStdOperatorTable.EQUALS, args, SqlParserPos.ZERO);
       // Force unique aliases to avoid a duplicate for Y with
       // SET X=Y
       String alias = SqlUtil.deriveAliasFromOrdinal(ordinal);


### PR DESCRIPTION
Companion Calcite PR for https://github.com/Bodo-inc/Bodo/pull/5521. Should be reviewed in tandem. What is changed:
- Modifications to the new `from` field created in an recently merged PR
- For validation purposes, modifies the generated `SELECT` of an `UPDATE` statement in the following way:
   - **UNCHANGED:** `UPDATE t1 SET A = 0 WHERE A < 0` -> `SELECT *, 0 FROM t1 WHERE A < 0`
   - **NEW:** `UPDATE t1 SET A = t2.A FROM t2 WHERE t1.id = t2.id` -> `SELECT *, t2.A FROM t1 CROSS JOIN t2 WHERE t1.id = t2.id` (this ensures that so far as the validator is concerned, `t2.XXX` is always accessible in the `SET` and `WHERE` clauses).

UPDATE: changes in this PR and an earlier one being reverted as more of the logic is being ported to our validator.

**Question:** do we want to go through with the self join / merge into transformations? If so, that should be done in this PR